### PR TITLE
Preserve unassigned rows in block splits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # qualtdict 0.0.0.9000
 
+- `dict_split_blocks()` and `survey_split_blocks()` now preserve unassigned
+  Variable Dictionary rows in a `"..unassigned"` split.
+
 - Improved rOpenSci package-check readiness by narrowing package imports,
   cleaning examples, reducing duplicated parameter documentation, and removing
   unused internal helpers.

--- a/R/split_blocks.R
+++ b/R/split_blocks.R
@@ -5,7 +5,8 @@
 #'
 #' @inheritParams dict_validate
 #'
-#' @return A named list of Variable Dictionaries, one per Survey Block.
+#' @return A named list of Variable Dictionaries, one per Survey Block. When
+#'   rows have no Survey Block assignment, the list includes `"..unassigned"`.
 #' @export
 #' @examples
 #' dict <- data.frame(
@@ -19,8 +20,15 @@
 dict_split_blocks <- function(dict) {
   checkarg_isqualtdict(dict)
 
+  unassigned <- is.na(dict$block)
+  assigned_blocks <- split(dict[!unassigned, ], dict$block[!unassigned])
+  unassigned_blocks <- list()
+  if (any(unassigned)) {
+    unassigned_blocks <- list("..unassigned" = dict[unassigned, ])
+  }
+
   map(
-    split(dict, dict$block),
+    c(unassigned_blocks, assigned_blocks),
     copy_qualtdict_attrs,
     source = dict
   )
@@ -44,7 +52,8 @@ dict_split_blocks <- function(dict) {
 #' \code{dict} attribute attached by
 #' \code{\link[qualtdict]{fetch_labelled_survey_data}}.
 #'
-#' @return A named list of data frames, one per Survey Block.
+#' @return A named list of data frames, one per Survey Block. When dictionary
+#'   rows have no Survey Block assignment, the list includes `"..unassigned"`.
 #' @export
 #' @examples
 #' dict <- data.frame(
@@ -64,13 +73,15 @@ dict_split_blocks <- function(dict) {
 #' attr(dat, "dict") <- dict
 #'
 #' survey_split_blocks(dat)
-survey_split_blocks <- function(dat,
-                                dict = attr(dat, "dict", exact = TRUE),
-                                extra_columns = c(
-                                  "externalDataReference",
-                                  "startDate",
-                                  "endDate"
-                                )) {
+survey_split_blocks <- function(
+  dat,
+  dict = attr(dat, "dict", exact = TRUE),
+  extra_columns = c(
+    "externalDataReference",
+    "startDate",
+    "endDate"
+  )
+) {
   if (!is.data.frame(dat)) {
     rlang::abort("`dat` must be Labelled Survey Data.")
   }

--- a/R/split_blocks.R
+++ b/R/split_blocks.R
@@ -20,15 +20,20 @@
 dict_split_blocks <- function(dict) {
   checkarg_isqualtdict(dict)
 
-  unassigned <- is.na(dict$block)
-  assigned_blocks <- split(dict[!unassigned, ], dict$block[!unassigned])
-  unassigned_blocks <- list()
-  if (any(unassigned)) {
-    unassigned_blocks <- list("..unassigned" = dict[unassigned, ])
+  unassigned_rows <- is.na(dict$block)
+  block_dicts <- split(
+    dict[!unassigned_rows, ],
+    dict$block[!unassigned_rows]
+  )
+  if (any(unassigned_rows)) {
+    block_dicts <- c(
+      list("..unassigned" = dict[unassigned_rows, ]),
+      block_dicts
+    )
   }
 
   map(
-    c(unassigned_blocks, assigned_blocks),
+    block_dicts,
     copy_qualtdict_attrs,
     source = dict
   )

--- a/man/dict_split_blocks.Rd
+++ b/man/dict_split_blocks.Rd
@@ -11,7 +11,8 @@ dict_split_blocks(dict)
 \code{\link[qualtdict]{dict_generate}}.}
 }
 \value{
-A named list of Variable Dictionaries, one per Survey Block.
+A named list of Variable Dictionaries, one per Survey Block. When
+rows have no Survey Block assignment, the list includes \code{"..unassigned"}.
 }
 \description{
 Create block-specific views of a Variable Dictionary without changing the

--- a/man/survey_split_blocks.Rd
+++ b/man/survey_split_blocks.Rd
@@ -24,7 +24,8 @@ user-specified columns error; missing default columns warn and are skipped.
 Use \code{NULL} to retain no extra columns.}
 }
 \value{
-A named list of data frames, one per Survey Block.
+A named list of data frames, one per Survey Block. When dictionary
+rows have no Survey Block assignment, the list includes \code{"..unassigned"}.
 }
 \description{
 Create block-specific views of Labelled Survey Data without changing the

--- a/tests/testthat/test-fetch_labelled_survey_data.R
+++ b/tests/testthat/test-fetch_labelled_survey_data.R
@@ -260,6 +260,62 @@ test_that("dict_split_blocks returns block-specific Variable Dictionaries", {
   )
 })
 
+test_that("dict_split_blocks preserves unassigned Variable Dictionary rows", {
+  dict <- minimal_export_dict(
+    response_column_id = c("QID1", "ED1"),
+    variable_name = c("q1", "embedded_field"),
+    block = c("Block A", NA_character_),
+    label = c("Yes", NA_character_),
+    level = c("1", NA_character_)
+  )
+  attr(dict, "variable_name_findings") <- tibble::tibble(
+    response_column_id = "ED1",
+    original_candidate = "Embedded Field",
+    variable_name = "embedded_field",
+    reason = "unsafe"
+  )
+
+  block_dicts <- dict_split_blocks(dict)
+
+  expect_named(block_dicts, c("..unassigned", "Block A"))
+  expect_s3_class(block_dicts[["..unassigned"]], "qualtdict")
+  expect_identical(
+    attr(block_dicts[["..unassigned"]], "surveyID", exact = TRUE),
+    "SV_TEST"
+  )
+  expect_identical(
+    block_dicts[["..unassigned"]]$response_column_id,
+    "ED1"
+  )
+  expect_identical(
+    attr(
+      block_dicts[["..unassigned"]],
+      "variable_name_findings"
+    )$response_column_id,
+    "ED1"
+  )
+  expect_identical(
+    nrow(attr(block_dicts[["Block A"]], "variable_name_findings")),
+    0L
+  )
+})
+
+test_that("dict_split_blocks keeps unassigned rows separate from block names", {
+  dict <- minimal_export_dict(
+    response_column_id = c("QID1", "ED1"),
+    variable_name = c("q1", "embedded_field"),
+    block = c("..unassigned", NA_character_),
+    label = c("Yes", NA_character_),
+    level = c("1", NA_character_)
+  )
+
+  block_dicts <- dict_split_blocks(dict)
+
+  expect_named(block_dicts, c("..unassigned", "..unassigned"))
+  expect_identical(block_dicts[[1]]$response_column_id, "ED1")
+  expect_identical(block_dicts[[2]]$response_column_id, "QID1")
+})
+
 test_that("survey_split_blocks returns block-specific Labelled Survey Data", {
   dat <- tibble::tibble(
     externalDataReference = "R_1",
@@ -292,4 +348,31 @@ test_that("survey_split_blocks returns block-specific Labelled Survey Data", {
     )
   )
   expect_s3_class(attr(block_data[["Block A"]], "dict"), "qualtdict")
+})
+
+test_that("survey_split_blocks preserves unassigned Export Variables", {
+  dict <- minimal_export_dict(
+    response_column_id = c("QID1", "ED1"),
+    variable_name = c("q1", "embedded_field"),
+    block = c("Block A", NA_character_),
+    label = c("Yes", NA_character_),
+    level = c("1", NA_character_)
+  )
+  dat <- tibble::tibble(
+    IPAddress = "127.0.0.1",
+    q1 = "1",
+    embedded_field = "wave_1"
+  )
+  attr(dat, "dict") <- dict
+
+  block_data <- survey_split_blocks(dat, extra_columns = "IPAddress")
+
+  expect_named(block_data, c("..unassigned", "Block A"))
+  expect_named(block_data[["..unassigned"]], c("IPAddress", "embedded_field"))
+  expect_named(block_data[["Block A"]], c("IPAddress", "q1"))
+  expect_s3_class(attr(block_data[["..unassigned"]], "dict"), "qualtdict")
+  expect_identical(
+    attr(block_data[["..unassigned"]], "dict")$response_column_id,
+    "ED1"
+  )
 })

--- a/tests/testthat/test-fetch_labelled_survey_data.R
+++ b/tests/testthat/test-fetch_labelled_survey_data.R
@@ -1,15 +1,18 @@
 minimal_export_dict <- function(
   response_column_id = c("QID1", "QID2"),
+  row_source = "question",
   variable_name = c("q1", "q2"),
+  qid = sub("_.*$", "", response_column_id),
+  question_name = variable_name,
   block = c("Block A", "Block B"),
   label = c("Yes", "No"),
   level = c("1", "2")
 ) {
   dict <- tibble::tibble(
     response_column_id = response_column_id,
-    row_source = "question",
-    qid = sub("_.*$", "", response_column_id),
-    question_name = variable_name,
+    row_source = row_source,
+    qid = qid,
+    question_name = question_name,
     variable_name = variable_name,
     block = block,
     question = paste("Question", variable_name),
@@ -263,6 +266,9 @@ test_that("dict_split_blocks returns block-specific Variable Dictionaries", {
 test_that("dict_split_blocks preserves unassigned Variable Dictionary rows", {
   dict <- minimal_export_dict(
     response_column_id = c("QID1", "ED1"),
+    row_source = c("question", "embedded_data"),
+    qid = c("QID1", NA_character_),
+    question_name = c("q1", NA_character_),
     variable_name = c("q1", "embedded_field"),
     block = c("Block A", NA_character_),
     label = c("Yes", NA_character_),
@@ -303,6 +309,9 @@ test_that("dict_split_blocks preserves unassigned Variable Dictionary rows", {
 test_that("dict_split_blocks keeps unassigned rows separate from block names", {
   dict <- minimal_export_dict(
     response_column_id = c("QID1", "ED1"),
+    row_source = c("question", "embedded_data"),
+    qid = c("QID1", NA_character_),
+    question_name = c("q1", NA_character_),
     variable_name = c("q1", "embedded_field"),
     block = c("..unassigned", NA_character_),
     label = c("Yes", NA_character_),
@@ -353,6 +362,9 @@ test_that("survey_split_blocks returns block-specific Labelled Survey Data", {
 test_that("survey_split_blocks preserves unassigned Export Variables", {
   dict <- minimal_export_dict(
     response_column_id = c("QID1", "ED1"),
+    row_source = c("question", "embedded_data"),
+    qid = c("QID1", NA_character_),
+    question_name = c("q1", NA_character_),
     variable_name = c("q1", "embedded_field"),
     block = c("Block A", NA_character_),
     label = c("Yes", NA_character_),


### PR DESCRIPTION
## Summary

- preserve Variable Dictionary rows with `block = NA` in a `"..unassigned"` split
- make `survey_split_blocks()` mirror the dictionary split for unassigned export variables
- document the `"..unassigned"` split and add regression coverage

## Validation

- `Rscript -e 'devtools::test()'`
- `Rscript -e 'devtools::check()'` (0 errors, 0 warnings, 2 environmental notes: linked-worktree `.git`, unable to verify current time)
- `Rscript tools/local-finalize-smoke.R check --root /home/andongni/Yandex.Disk/Projects/Research/packages/qualtdict/.local/finalize-smoke --survey-seed 123 --functions dict_split_blocks,survey_split_blocks --variable-name all`
- pre-push hooks, including full rOpenSci `pkgcheck` audit and R CMD check without manual

Fixes #13
