### PR TITLE
Add Embedded Data Field Survey Flow block assignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # qualtdict 0.0.0.9000
 
+- `dict_generate()` now accepts `embedded_data_block_assignment` to optionally
+  assign Survey Flow Embedded Data Fields to the nearest previous or next
+  Survey Block while leaving them unassigned by default.
+
 - `dict_generate()` now represents flat Embedded Data Fields from Qualtrics
   metadata as Metadata-defined Export Variable rows with
   `row_source = "embedded_data"`.

--- a/R/dict_generate.R
+++ b/R/dict_generate.R
@@ -22,6 +22,11 @@
 #' this function are not included in the returned Variable Dictionary.
 #' @param preprocess Deprecated compatibility alias for
 #' \code{semantic_name_preprocess}.
+#' @param embedded_data_block_assignment String. Survey Flow adjacency policy
+#' for assigning Embedded Data Fields to Survey Blocks. Use \code{"none"} to
+#' leave Embedded Data Fields unassigned, \code{"previous"} to assign fields
+#' with an unambiguous Survey Flow location to the nearest previous Survey
+#' Block, or \code{"next"} to assign them to the nearest next Survey Block.
 #' @param quiet Boolean. If \code{TRUE}, suppress routine progress messages and
 #' progress bars. Defaults to \code{TRUE}.
 #' @param block_sep String. Separator between variable names and block
@@ -34,7 +39,10 @@
 #' \code{variable_name} as the final export-safe Dictionary Variable Name used
 #' by Labelled Survey Data. Question-backed rows use
 #' \code{row_source = "question"}. Flat Embedded Data Fields defined by
-#' Qualtrics metadata use \code{row_source = "embedded_data"}.
+#' Qualtrics metadata use \code{row_source = "embedded_data"}. Embedded Data
+#' Fields remain unassigned by Survey Block unless
+#' \code{embedded_data_block_assignment} explicitly requests Survey Flow
+#' adjacency assignment.
 #'
 #' When \code{variable_name = "semantic_name"}, the Variable Dictionary also
 #' includes \code{semantic_name}. Semantic Names are readable best-effort
@@ -73,6 +81,7 @@ dict_generate <- function(
   block_sep = ".",
   semantic_name_preprocess = NULL,
   preprocess = NULL,
+  embedded_data_block_assignment = c("none", "previous", "next"),
   quiet = TRUE
 ) {
   check_dict_generate_args(
@@ -82,6 +91,10 @@ dict_generate <- function(
     semantic_name_preprocess = semantic_name_preprocess,
     preprocess = preprocess,
     quiet = quiet
+  )
+  embedded_data_block_assignment <- match.arg(
+    embedded_data_block_assignment,
+    c("none", "previous", "next")
   )
   variable_name <- resolve_dict_generate_variable_name(variable_name, name)
   semantic_name_preprocess <- resolve_semantic_name_preprocess(
@@ -99,6 +112,7 @@ dict_generate <- function(
     block_pattern = block_pattern,
     block_sep = block_sep,
     semantic_name_preprocess = semantic_name_preprocess,
+    embedded_data_block_assignment = embedded_data_block_assignment,
     quiet = quiet
   )
 

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -123,19 +123,25 @@ survey_flow_items <- function(flow) {
     return(list())
   }
 
-  items <- flow$Flow %||% flow$flow
-  if (is.null(items)) {
-    if (!is.na(survey_flow_item_type(flow))) {
+  if (!is.na(survey_flow_item_type(flow))) {
+    items <- flow$Flow %||% flow$flow
+    if (is.null(items)) {
       return(list(flow))
     }
 
-    items <- flow
-  }
-  if (is.null(names(items))) {
-    return(items)
+    return(survey_flow_items(items))
   }
 
-  unname(items)
+  items <- flow$Flow %||% flow$flow %||% flow
+  if (!is.null(names(items))) {
+    items <- unname(items)
+  }
+
+  unlist(
+    map(items, survey_flow_items),
+    recursive = FALSE,
+    use.names = FALSE
+  )
 }
 
 survey_flow_block_lookup <- function(blocks) {

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -63,17 +63,11 @@ normalise_survey_flow_embedded_data_fields <- function(mt, mt_d) {
   }
 
   block_lookup <- survey_flow_block_lookup(mt_d$block)
-  block_names <- map_chr(flow_items, function(item) {
-    block_id <- survey_flow_block_id(item)
-    if (is.na(block_id)) {
-      return(NA_character_)
-    }
-    if (!block_id %in% names(block_lookup)) {
-      return(NA_character_)
-    }
-
-    block_lookup[[block_id]] %||% NA_character_
-  })
+  block_names <- map_chr(
+    flow_items,
+    survey_flow_block_name,
+    block_lookup = block_lookup
+  )
 
   field_locations <- map2(
     flow_items,
@@ -87,10 +81,11 @@ normalise_survey_flow_embedded_data_fields <- function(mt, mt_d) {
     return(empty_normalised_embedded_data_fields())
   }
 
-  field_names <- unique(map_chr(field_locations, "field_name"))
+  location_field_names <- map_chr(field_locations, "field_name")
+  field_names <- unique(location_field_names)
   fields <- map(field_names, function(field_name) {
     normalise_survey_flow_embedded_data_field(
-      field_locations[map_chr(field_locations, "field_name") == field_name]
+      field_locations[location_field_names == field_name]
     )
   })
   names(fields) <- map_chr(fields, "field_name")
@@ -153,6 +148,15 @@ survey_flow_block_lookup <- function(blocks) {
   })
 }
 
+survey_flow_block_name <- function(item, block_lookup) {
+  block_id <- survey_flow_block_id(item)
+  if (is.na(block_id) || !block_id %in% names(block_lookup)) {
+    return(NA_character_)
+  }
+
+  block_lookup[[block_id]] %||% NA_character_
+}
+
 survey_flow_block_id <- function(item) {
   if (!identical(survey_flow_item_type(item), "Block")) {
     return(NA_character_)
@@ -184,8 +188,8 @@ survey_flow_embedded_data_field_locations <- function(
     return(list())
   }
 
-  previous_block <- last_block_before(block_names, item_index)
-  next_block <- first_block_after(block_names, item_index)
+  previous_block <- previous_survey_flow_block(block_names, item_index)
+  next_block <- next_survey_flow_block(block_names, item_index)
   map(field_names, function(field_name) {
     list(
       field_name = field_name,
@@ -225,7 +229,7 @@ is_embedded_data_field_record <- function(field) {
     any(embedded_data_field_name_columns %in% names(field))
 }
 
-last_block_before <- function(block_names, item_index) {
+previous_survey_flow_block <- function(block_names, item_index) {
   if (item_index <= 1) {
     return(NA_character_)
   }
@@ -239,7 +243,7 @@ last_block_before <- function(block_names, item_index) {
   previous_blocks[[length(previous_blocks)]]
 }
 
-first_block_after <- function(block_names, item_index) {
+next_survey_flow_block <- function(block_names, item_index) {
   if (item_index >= length(block_names)) {
     return(NA_character_)
   }

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -11,7 +11,10 @@ normalise_qualtrics_metadata <- function(raw_metadata) {
     raw_metadata$metadata,
     raw_metadata$description
   )
-  embedded_data <- normalise_flat_embedded_data_fields(raw_metadata$metadata)
+  embedded_data <- normalise_embedded_data_fields(
+    raw_metadata$metadata,
+    raw_metadata$description
+  )
 
   structure(
     list(
@@ -22,6 +25,13 @@ normalise_qualtrics_metadata <- function(raw_metadata) {
     ),
     class = c("qualtdict_normalised_metadata", "list")
   )
+}
+
+normalise_embedded_data_fields <- function(mt, mt_d) {
+  flat_fields <- normalise_flat_embedded_data_fields(mt)
+  flow_fields <- normalise_survey_flow_embedded_data_fields(mt, mt_d)
+
+  merge_embedded_data_fields(flat_fields, flow_fields)
 }
 
 normalise_flat_embedded_data_fields <- function(mt) {
@@ -43,6 +53,225 @@ normalise_flat_embedded_data_fields <- function(mt) {
   structure(
     fields,
     class = c("qualtdict_normalised_embedded_data_fields", "list")
+  )
+}
+
+normalise_survey_flow_embedded_data_fields <- function(mt, mt_d) {
+  flow_items <- survey_flow_items(mt$flow %||% mt_d$flow)
+  if (length(flow_items) == 0) {
+    return(empty_normalised_embedded_data_fields())
+  }
+
+  block_lookup <- survey_flow_block_lookup(mt_d$block)
+  block_names <- map_chr(flow_items, function(item) {
+    block_id <- survey_flow_block_id(item)
+    if (is.na(block_id)) {
+      return(NA_character_)
+    }
+    if (!block_id %in% names(block_lookup)) {
+      return(NA_character_)
+    }
+
+    block_lookup[[block_id]] %||% NA_character_
+  })
+
+  field_locations <- map2(
+    flow_items,
+    seq_along(flow_items),
+    survey_flow_embedded_data_field_locations,
+    block_names = block_names
+  ) |>
+    do.call(c, args = _)
+
+  if (length(field_locations) == 0) {
+    return(empty_normalised_embedded_data_fields())
+  }
+
+  field_names <- unique(map_chr(field_locations, "field_name"))
+  fields <- map(field_names, function(field_name) {
+    normalise_survey_flow_embedded_data_field(
+      field_locations[map_chr(field_locations, "field_name") == field_name]
+    )
+  })
+  names(fields) <- map_chr(fields, "field_name")
+
+  structure(
+    fields,
+    class = c("qualtdict_normalised_embedded_data_fields", "list")
+  )
+}
+
+empty_normalised_embedded_data_fields <- function() {
+  structure(
+    list(),
+    class = c("qualtdict_normalised_embedded_data_fields", "list")
+  )
+}
+
+merge_embedded_data_fields <- function(flat_fields, flow_fields) {
+  fields <- flat_fields
+  for (field_name in names(flow_fields)) {
+    fields[[field_name]] <- utils::modifyList(
+      fields[[field_name]] %||% list(),
+      flow_fields[[field_name]]
+    )
+  }
+
+  structure(
+    fields,
+    class = c("qualtdict_normalised_embedded_data_fields", "list")
+  )
+}
+
+survey_flow_items <- function(flow) {
+  if (is.null(flow) || length(flow) == 0) {
+    return(list())
+  }
+
+  items <- flow$Flow %||% flow$flow
+  if (is.null(items)) {
+    if (!is.na(survey_flow_item_type(flow))) {
+      return(list(flow))
+    }
+
+    items <- flow
+  }
+  if (is.null(names(items))) {
+    return(items)
+  }
+
+  unname(items)
+}
+
+survey_flow_block_lookup <- function(blocks) {
+  if (is.null(blocks) || length(blocks) == 0) {
+    return(character())
+  }
+
+  imap_chr(blocks, function(block, block_id) {
+    scalar_character(block$Description %||% block$description %||% block_id)
+  })
+}
+
+survey_flow_block_id <- function(item) {
+  if (!identical(survey_flow_item_type(item), "Block")) {
+    return(NA_character_)
+  }
+
+  scalar_character(
+    item$ID %||%
+      item$BlockID %||%
+      item$BlockId %||%
+      item$id
+  )
+}
+
+survey_flow_item_type <- function(item) {
+  scalar_character(item$Type %||% item$FlowType %||% item$type)
+}
+
+survey_flow_embedded_data_field_locations <- function(
+  item,
+  item_index,
+  block_names
+) {
+  if (!identical(survey_flow_item_type(item), "EmbeddedData")) {
+    return(list())
+  }
+
+  field_names <- survey_flow_embedded_data_field_names(item)
+  if (length(field_names) == 0) {
+    return(list())
+  }
+
+  previous_block <- last_block_before(block_names, item_index)
+  next_block <- first_block_after(block_names, item_index)
+  map(field_names, function(field_name) {
+    list(
+      field_name = field_name,
+      previous_block = previous_block,
+      next_block = next_block
+    )
+  })
+}
+
+survey_flow_embedded_data_field_names <- function(item) {
+  embedded_data <- item$EmbeddedData %||%
+    item$EmbeddedDataFields %||%
+    item$Fields %||%
+    item$embeddedData %||%
+    item$embedded_data
+
+  if (is.null(embedded_data)) {
+    if (is_embedded_data_field_record(item)) {
+      return(valid_embedded_data_field_names(
+        embedded_data_field_name(item)
+      ))
+    }
+
+    return(character())
+  }
+  if (is_embedded_data_field_record(embedded_data)) {
+    return(valid_embedded_data_field_names(
+      embedded_data_field_name(embedded_data)
+    ))
+  }
+
+  embedded_data_field_names(embedded_data)
+}
+
+is_embedded_data_field_record <- function(field) {
+  is.list(field) &&
+    any(embedded_data_field_name_columns %in% names(field))
+}
+
+last_block_before <- function(block_names, item_index) {
+  if (item_index <= 1) {
+    return(NA_character_)
+  }
+
+  previous_blocks <- block_names[seq_len(item_index - 1)]
+  previous_blocks <- previous_blocks[!is.na(previous_blocks)]
+  if (length(previous_blocks) == 0) {
+    return(NA_character_)
+  }
+
+  previous_blocks[[length(previous_blocks)]]
+}
+
+first_block_after <- function(block_names, item_index) {
+  if (item_index >= length(block_names)) {
+    return(NA_character_)
+  }
+
+  next_blocks <- block_names[seq.int(item_index + 1, length(block_names))]
+  next_blocks <- next_blocks[!is.na(next_blocks)]
+  if (length(next_blocks) == 0) {
+    return(NA_character_)
+  }
+
+  next_blocks[[1]]
+}
+
+normalise_survey_flow_embedded_data_field <- function(locations) {
+  field_name <- locations[[1]]$field_name
+  if (length(locations) == 1) {
+    previous_block <- locations[[1]]$previous_block
+    next_block <- locations[[1]]$next_block
+  } else {
+    previous_block <- NA_character_
+    next_block <- NA_character_
+  }
+
+  structure(
+    list(
+      field_name = field_name,
+      response_column_id = field_name,
+      question_text = paste("Embedded Data:", field_name),
+      previous_block = previous_block,
+      next_block = next_block
+    ),
+    class = c("qualtdict_normalised_embedded_data_field", "list")
   )
 }
 

--- a/R/variable_dictionary.R
+++ b/R/variable_dictionary.R
@@ -193,9 +193,7 @@ warn_unassigned_embedded_data_rows <- function(
     return(invisible())
   }
 
-  unassigned <- map_lgl(rows, function(row) {
-    is.na(row$block)
-  })
+  unassigned <- map_lgl(rows, ~ is.na(.x$block))
   if (any(unassigned)) {
     warning(
       "Some Embedded Data Fields could not be assigned to a Survey Block ",

--- a/R/variable_dictionary.R
+++ b/R/variable_dictionary.R
@@ -43,6 +43,7 @@ variable_dictionary_from_normalised_metadata <- function(
   block_pattern,
   block_sep,
   semantic_name_preprocess,
+  embedded_data_block_assignment = "none",
   quiet = TRUE
 ) {
   question_meta <- normalised_metadata$questions
@@ -52,7 +53,11 @@ variable_dictionary_from_normalised_metadata <- function(
 
   json <- c(
     variable_dictionary_question_rows(question_meta),
-    variable_dictionary_embedded_data_rows(normalised_metadata$embedded_data)
+    variable_dictionary_embedded_data_rows(
+      normalised_metadata$embedded_data,
+      embedded_data_block_assignment = embedded_data_block_assignment,
+      quiet = quiet
+    )
   )
   if (length(json) == 0) {
     return(empty_variable_dictionary_from_normalised_metadata(
@@ -120,11 +125,30 @@ variable_dictionary_question_row <- function(qjson, qid) {
   )
 }
 
-variable_dictionary_embedded_data_rows <- function(embedded_data) {
-  imap(embedded_data %||% list(), variable_dictionary_embedded_data_row)
+variable_dictionary_embedded_data_rows <- function(
+  embedded_data,
+  embedded_data_block_assignment = "none",
+  quiet = TRUE
+) {
+  rows <- imap(
+    embedded_data %||% list(),
+    variable_dictionary_embedded_data_row,
+    embedded_data_block_assignment = embedded_data_block_assignment
+  )
+  warn_unassigned_embedded_data_rows(
+    rows,
+    embedded_data_block_assignment = embedded_data_block_assignment,
+    quiet = quiet
+  )
+
+  rows
 }
 
-variable_dictionary_embedded_data_row <- function(field, field_name) {
+variable_dictionary_embedded_data_row <- function(
+  field,
+  field_name,
+  embedded_data_block_assignment = "none"
+) {
   field_name <- field$field_name %||% field_name
 
   list(
@@ -133,7 +157,10 @@ variable_dictionary_embedded_data_row <- function(field, field_name) {
     row_source = "embedded_data",
     question_name = NA_character_,
     variable_name = field_name,
-    block = NA_character_,
+    block = embedded_data_field_block(
+      field,
+      embedded_data_block_assignment
+    ),
     question = field$question_text %||% paste("Embedded Data:", field_name),
     looping_question = NA_character_,
     item = NA_character_,
@@ -146,6 +173,40 @@ variable_dictionary_embedded_data_row <- function(field, field_name) {
     looping_option = NA_character_,
     looping = FALSE
   )
+}
+
+embedded_data_field_block <- function(field, embedded_data_block_assignment) {
+  switch(
+    embedded_data_block_assignment,
+    none = NA_character_,
+    previous = field$previous_block %||% NA_character_,
+    "next" = field$next_block %||% NA_character_
+  )
+}
+
+warn_unassigned_embedded_data_rows <- function(
+  rows,
+  embedded_data_block_assignment,
+  quiet
+) {
+  if (quiet || identical(embedded_data_block_assignment, "none")) {
+    return(invisible())
+  }
+
+  unassigned <- map_lgl(rows, function(row) {
+    is.na(row$block)
+  })
+  if (any(unassigned)) {
+    warning(
+      "Some Embedded Data Fields could not be assigned to a Survey Block ",
+      "using `embedded_data_block_assignment = \"",
+      embedded_data_block_assignment,
+      "\"`.",
+      call. = FALSE
+    )
+  }
+
+  invisible()
 }
 
 prepare_variable_dictionary_rows <- function(json) {

--- a/man/dict_generate.Rd
+++ b/man/dict_generate.Rd
@@ -12,6 +12,7 @@ dict_generate(
   block_sep = ".",
   semantic_name_preprocess = NULL,
   preprocess = NULL,
+  embedded_data_block_assignment = c("none", "previous", "next"),
   quiet = TRUE
 )
 }
@@ -44,6 +45,12 @@ this function are not included in the returned Variable Dictionary.}
 \item{preprocess}{Deprecated compatibility alias for
 \code{semantic_name_preprocess}.}
 
+\item{embedded_data_block_assignment}{String. Survey Flow adjacency policy
+for assigning Embedded Data Fields to Survey Blocks. Use \code{"none"} to
+leave Embedded Data Fields unassigned, \code{"previous"} to assign fields
+with an unambiguous Survey Flow location to the nearest previous Survey
+Block, or \code{"next"} to assign them to the nearest next Survey Block.}
+
 \item{quiet}{Boolean. If \code{TRUE}, suppress routine progress messages and
 progress bars. Defaults to \code{TRUE}.}
 }
@@ -62,7 +69,10 @@ identifier, \code{row_source} as the Dictionary Row Source,
 \code{variable_name} as the final export-safe Dictionary Variable Name used
 by Labelled Survey Data. Question-backed rows use
 \code{row_source = "question"}. Flat Embedded Data Fields defined by
-Qualtrics metadata use \code{row_source = "embedded_data"}.
+Qualtrics metadata use \code{row_source = "embedded_data"}. Embedded Data
+Fields remain unassigned by Survey Block unless
+\code{embedded_data_block_assignment} explicitly requests Survey Flow
+adjacency assignment.
 
 When \code{variable_name = "semantic_name"}, the Variable Dictionary also
 includes \code{semantic_name}. Semantic Names are readable best-effort

--- a/tests/testthat/helper-normalised-metadata.R
+++ b/tests/testthat/helper-normalised-metadata.R
@@ -62,6 +62,59 @@ synthetic_flat_embedded_data_raw_metadata <- function() {
   raw_metadata
 }
 
+synthetic_survey_flow_embedded_data_raw_metadata <- function() {
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$metadata$questions$QID2 <- raw_metadata$metadata$questions$QID1
+  raw_metadata$metadata$questions$QID2$questionName <- "Q2"
+  raw_metadata$metadata$questions$QID2$questionText <- "Follow-up question"
+  raw_metadata$description$question$QID2 <-
+    raw_metadata$description$question$QID1
+  raw_metadata$description$block$BL_2 <- raw_metadata$description$block$BL_1
+  raw_metadata$description$block$BL_2$Description <- "Follow-up Block"
+  raw_metadata$description$block$BL_2$BlockElements <- list(
+    list(QuestionID = "QID2")
+  )
+  raw_metadata$metadata$flow <- list(
+    Flow = list(
+      list(
+        Type = "EmbeddedData",
+        EmbeddedData = list(list(Field = "Before Main"))
+      ),
+      list(Type = "Block", ID = "BL_1"),
+      list(
+        Type = "EmbeddedData",
+        EmbeddedData = list(list(Field = "Between Blocks"))
+      ),
+      list(Type = "Block", ID = "BL_2"),
+      list(
+        Type = "EmbeddedData",
+        EmbeddedData = list(list(Field = "After Follow-up"))
+      )
+    )
+  )
+
+  raw_metadata
+}
+
+synthetic_ambiguous_survey_flow_embedded_data_raw_metadata <- function() {
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$metadata$flow <- list(
+    Flow = list(
+      list(
+        Type = "EmbeddedData",
+        EmbeddedData = list(list(Field = "Duplicated Field"))
+      ),
+      list(Type = "Block", ID = "BL_1"),
+      list(
+        Type = "EmbeddedData",
+        EmbeddedData = list(list(Field = "Duplicated Field"))
+      )
+    )
+  )
+
+  raw_metadata
+}
+
 synthetic_loop_and_merge_raw_metadata <- function(
   question_text = "Why did you choose ${lm://Field/1}?"
 ) {

--- a/tests/testthat/helper-normalised-metadata.R
+++ b/tests/testthat/helper-normalised-metadata.R
@@ -96,6 +96,16 @@ synthetic_survey_flow_embedded_data_raw_metadata <- function() {
   raw_metadata
 }
 
+synthetic_nested_survey_flow_embedded_data_raw_metadata <- function() {
+  raw_metadata <- synthetic_survey_flow_embedded_data_raw_metadata()
+  raw_metadata$metadata$flow$Flow[[3]] <- list(
+    Type = "Branch",
+    Flow = list(raw_metadata$metadata$flow$Flow[[3]])
+  )
+
+  raw_metadata
+}
+
 synthetic_ambiguous_survey_flow_embedded_data_raw_metadata <- function() {
   raw_metadata <- synthetic_mc_text_raw_metadata()
   raw_metadata$metadata$flow <- list(

--- a/tests/testthat/test-dict_generate.R
+++ b/tests/testthat/test-dict_generate.R
@@ -164,6 +164,26 @@ test_that("dict_generate assigns Embedded Data Fields to next blocks", {
   )
 })
 
+test_that("dict_generate assigns nested Embedded Data Fields", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_nested_survey_flow_embedded_data_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate(
+    "SV_SYNTHETIC",
+    variable_name = "question_name",
+    embedded_data_block_assignment = "previous"
+  )
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_identical(
+    embedded_rows$block,
+    c(NA_character_, "Main Block", "Follow-up Block")
+  )
+})
+
 test_that("dict_generate leaves flat Embedded Data Fields unassigned", {
   local_mocked_bindings(
     fetch_dictionary_metadata = function(surveyID) {

--- a/tests/testthat/test-dict_generate.R
+++ b/tests/testthat/test-dict_generate.R
@@ -107,6 +107,131 @@ test_that("dict_generate represents flat Embedded Data Fields", {
   )
 })
 
+test_that("dict_generate assigns Embedded Data Fields to previous blocks", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_survey_flow_embedded_data_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate(
+    "SV_SYNTHETIC",
+    variable_name = "question_name",
+    embedded_data_block_assignment = "previous"
+  )
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_identical(
+    embedded_rows$response_column_id,
+    c("Before Main", "Between Blocks", "After Follow-up")
+  )
+  expect_identical(
+    embedded_rows$block,
+    c(NA_character_, "Main Block", "Follow-up Block")
+  )
+})
+
+test_that("dict_generate defaults flow Embedded Data Fields to no block", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_survey_flow_embedded_data_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate("SV_SYNTHETIC", variable_name = "question_name")
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_true(all(is.na(embedded_rows$block)))
+})
+
+test_that("dict_generate assigns Embedded Data Fields to next blocks", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_survey_flow_embedded_data_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate(
+    "SV_SYNTHETIC",
+    variable_name = "question_name",
+    embedded_data_block_assignment = "next"
+  )
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_identical(
+    embedded_rows$block,
+    c("Main Block", "Follow-up Block", NA_character_)
+  )
+})
+
+test_that("dict_generate leaves flat Embedded Data Fields unassigned", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_flat_embedded_data_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate(
+    "SV_SYNTHETIC",
+    variable_name = "question_name",
+    embedded_data_block_assignment = "previous"
+  )
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_true(all(is.na(embedded_rows$block)))
+})
+
+test_that("dict_generate warns once for partial Embedded Data assignment", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_survey_flow_embedded_data_raw_metadata()
+    }
+  )
+
+  expect_warning(
+    dict <- dict_generate(
+      "SV_SYNTHETIC",
+      variable_name = "question_name",
+      embedded_data_block_assignment = "previous",
+      quiet = FALSE
+    ),
+    "Some Embedded Data Fields could not be assigned"
+  )
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_identical(
+    embedded_rows$block,
+    c(NA_character_, "Main Block", "Follow-up Block")
+  )
+  expect_silent(
+    dict_generate(
+      "SV_SYNTHETIC",
+      variable_name = "question_name",
+      embedded_data_block_assignment = "previous",
+      quiet = TRUE
+    )
+  )
+})
+
+test_that("dict_generate leaves ambiguous Embedded Data Fields unassigned", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_ambiguous_survey_flow_embedded_data_raw_metadata()
+    }
+  )
+
+  dict <- suppressWarnings(dict_generate(
+    "SV_SYNTHETIC",
+    variable_name = "question_name",
+    embedded_data_block_assignment = "previous",
+    quiet = FALSE
+  ))
+  embedded_rows <- dict[dict$row_source == "embedded_data", ]
+
+  expect_identical(embedded_rows$response_column_id, "Duplicated Field")
+  expect_true(is.na(embedded_rows$block))
+})
+
 test_that("dict_validate reports repaired Embedded Data Field names", {
   local_mocked_bindings(
     fetch_dictionary_metadata = function(surveyID) {

--- a/tests/testthat/test-normalise_metadata.R
+++ b/tests/testthat/test-normalise_metadata.R
@@ -67,6 +67,71 @@ test_that("flat Embedded Data Fields normalise into package-owned metadata", {
   )
 })
 
+test_that("Survey Flow Embedded Data Fields normalise with block candidates", {
+  raw_metadata <- synthetic_survey_flow_embedded_data_raw_metadata()
+  raw_metadata$metadata$flow$Flow[[1]]$EmbeddedData <-
+    list(Field = "Before Main", Value = "ignored")
+  raw_metadata$metadata$flow$Flow <- append(
+    raw_metadata$metadata$flow$Flow,
+    list(list(type = "EmbeddedData")),
+    after = 1
+  )
+
+  normalised_metadata <- normalise_qualtrics_metadata(raw_metadata)
+  embedded_data <- normalised_metadata$embedded_data
+
+  expect_named(
+    embedded_data,
+    c("Before Main", "Between Blocks", "After Follow-up")
+  )
+  expect_identical(
+    embedded_data[["Before Main"]]$previous_block,
+    NA_character_
+  )
+  expect_identical(
+    embedded_data[["Before Main"]]$next_block,
+    "Main Block"
+  )
+  expect_identical(
+    embedded_data[["Between Blocks"]]$previous_block,
+    "Main Block"
+  )
+  expect_identical(
+    embedded_data[["Between Blocks"]]$next_block,
+    "Follow-up Block"
+  )
+})
+
+test_that("Survey Flow Embedded Data normalisation handles defensive shapes", {
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$metadata$flow <- list(
+    Flow = list(
+      list(Type = "Block", ID = "BL_UNKNOWN"),
+      list(type = "EmbeddedData")
+    )
+  )
+  expect_length(
+    normalise_qualtrics_metadata(raw_metadata)$embedded_data,
+    0
+  )
+
+  raw_metadata$metadata$flow <- list(
+    Type = "EmbeddedData",
+    EmbeddedData = list(Field = "Single Flow Field")
+  )
+  embedded_data <- normalise_qualtrics_metadata(raw_metadata)$embedded_data
+
+  expect_named(embedded_data, "Single Flow Field")
+  expect_identical(
+    embedded_data[["Single Flow Field"]]$previous_block,
+    NA_character_
+  )
+  expect_identical(
+    embedded_data[["Single Flow Field"]]$next_block,
+    NA_character_
+  )
+})
+
 test_that("Embedded Data Field names normalise from supported flat shapes", {
   expect_identical(
     embedded_data_field_names(tibble::tibble(fieldName = c("Wave", "", NA))),

--- a/tests/testthat/test-normalise_metadata.R
+++ b/tests/testthat/test-normalise_metadata.R
@@ -102,6 +102,26 @@ test_that("Survey Flow Embedded Data Fields normalise with block candidates", {
   )
 })
 
+test_that("nested Survey Flow Embedded Data Fields normalise with candidates", {
+  raw_metadata <- synthetic_nested_survey_flow_embedded_data_raw_metadata()
+
+  normalised_metadata <- normalise_qualtrics_metadata(raw_metadata)
+  embedded_data <- normalised_metadata$embedded_data
+
+  expect_named(
+    embedded_data,
+    c("Before Main", "Between Blocks", "After Follow-up")
+  )
+  expect_identical(
+    embedded_data[["Between Blocks"]]$previous_block,
+    "Main Block"
+  )
+  expect_identical(
+    embedded_data[["Between Blocks"]]$next_block,
+    "Follow-up Block"
+  )
+})
+
 test_that("Survey Flow Embedded Data normalisation handles defensive shapes", {
   raw_metadata <- synthetic_mc_text_raw_metadata()
   raw_metadata$metadata$flow <- list(
@@ -115,6 +135,55 @@ test_that("Survey Flow Embedded Data normalisation handles defensive shapes", {
     0
   )
 
+  raw_metadata$metadata$flow <- list(
+    first = list(Type = "EmbeddedData", Field = "Named Flow Field")
+  )
+  embedded_data <- normalise_qualtrics_metadata(raw_metadata)$embedded_data
+
+  expect_named(embedded_data, "Named Flow Field")
+  expect_identical(
+    embedded_data[["Named Flow Field"]]$previous_block,
+    NA_character_
+  )
+  expect_identical(
+    embedded_data[["Named Flow Field"]]$next_block,
+    NA_character_
+  )
+
+  raw_metadata$description$block <- NULL
+  raw_metadata$metadata$flow <- list(
+    Flow = list(
+      list(Type = "Block", ID = "BL_1"),
+      list(Type = "EmbeddedData", Field = "No Block Lookup")
+    )
+  )
+  embedded_data <- normalise_survey_flow_embedded_data_fields(
+    raw_metadata$metadata,
+    raw_metadata$description
+  )
+
+  expect_named(embedded_data, "No Block Lookup")
+  expect_identical(
+    embedded_data[["No Block Lookup"]]$previous_block,
+    NA_character_
+  )
+
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$metadata$flow <- list(
+    Flow = list(
+      list(Type = "EmbeddedData", Field = "No Next Block"),
+      list(Type = "Block", ID = "BL_UNKNOWN")
+    )
+  )
+  embedded_data <- normalise_qualtrics_metadata(raw_metadata)$embedded_data
+
+  expect_named(embedded_data, "No Next Block")
+  expect_identical(
+    embedded_data[["No Next Block"]]$next_block,
+    NA_character_
+  )
+
+  raw_metadata <- synthetic_mc_text_raw_metadata()
   raw_metadata$metadata$flow <- list(
     Type = "EmbeddedData",
     EmbeddedData = list(Field = "Single Flow Field")


### PR DESCRIPTION
## Summary
- Add `embedded_data_block_assignment` to `dict_generate()` with `none`, `previous`, and `next` policies.
- Normalize Survey Flow Embedded Data Field locations, including nested flow containers.
- Cover default unassigned behavior, previous/next assignment, ambiguous fields, flat fields, and nested flow items in tests.

Fixes #15

## Verification
- `Rscript -e 'devtools::test()'`\n- `Rscript tools/local-finalize-smoke.R check --functions dict_generate --variable-name question_name`\n- `git push -u origin sandcastle/issue-15` pre-push hook passed full rOpenSci pkgcheck audit and R CMD check.