### PR TITLE
Represent scoring variables

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,7 @@
 ^\.direnv$
 ^\.direnv/
 ^\.envrc$
+^\.git$
 ^\.github$
 ^\.lavish$
 ^\.lavish/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # qualtdict 0.0.0.9000
 
+- `dict_generate()` now represents Scoring Variables from Qualtrics survey
+  description metadata as Metadata-defined Export Variable rows with
+  `row_source = "scoring"`.
+
 - `dict_generate()` now accepts `embedded_data_block_assignment` to optionally
   assign Survey Flow Embedded Data Fields to the nearest previous or next
   Survey Block while leaving them unassigned by default.

--- a/R/dict_generate.R
+++ b/R/dict_generate.R
@@ -39,10 +39,12 @@
 #' \code{variable_name} as the final export-safe Dictionary Variable Name used
 #' by Labelled Survey Data. Question-backed rows use
 #' \code{row_source = "question"}. Flat Embedded Data Fields defined by
-#' Qualtrics metadata use \code{row_source = "embedded_data"}. Embedded Data
-#' Fields remain unassigned by Survey Block unless
+#' Qualtrics metadata use \code{row_source = "embedded_data"}. Scoring
+#' Variables defined by survey description metadata use
+#' \code{row_source = "scoring"}. Embedded Data Fields remain unassigned by
+#' Survey Block unless
 #' \code{embedded_data_block_assignment} explicitly requests Survey Flow
-#' adjacency assignment.
+#' adjacency assignment. Scoring Variables remain unassigned by Survey Block.
 #'
 #' When \code{variable_name = "semantic_name"}, the Variable Dictionary also
 #' includes \code{semantic_name}. Semantic Names are readable best-effort

--- a/R/metadata_fetch.R
+++ b/R/metadata_fetch.R
@@ -26,7 +26,8 @@ fetch_dictionary_metadata <- function(surveyID) {
       "questions",
       "metadata",
       "blocks",
-      "flow"
+      "flow",
+      "scoring"
     )
   )
 

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -15,16 +15,214 @@ normalise_qualtrics_metadata <- function(raw_metadata) {
     raw_metadata$metadata,
     raw_metadata$description
   )
+  scoring <- normalise_scoring_variables(raw_metadata$description)
 
   structure(
     list(
       surveyID = raw_metadata$surveyID,
       survey_name = raw_metadata$survey_name,
       questions = questions,
-      embedded_data = embedded_data
+      embedded_data = embedded_data,
+      scoring = scoring
     ),
     class = c("qualtdict_normalised_metadata", "list")
   )
+}
+
+normalise_scoring_variables <- function(mt_d) {
+  scoring <- mt_d$scoring %||%
+    mt_d$Scoring %||%
+    mt_d$scoringData %||%
+    mt_d$ScoringData
+  scoring <- scoring_variable_definitions(scoring)
+  output_names <- scoring_variable_names(scoring)
+
+  variables <- map(output_names, function(output_name) {
+    output <- scoring_variable_record(scoring, output_name)
+    response_column_id <- scoring_variable_response_column_id(
+      output,
+      output_name
+    )
+
+    structure(
+      list(
+        output_name = output_name,
+        response_column_id = response_column_id,
+        question_text = paste("Scoring Variable:", output_name)
+      ),
+      class = c("qualtdict_normalised_scoring_variable", "list")
+    )
+  })
+  names(variables) <- output_names
+
+  structure(
+    variables,
+    class = c("qualtdict_normalised_scoring_variables", "list")
+  )
+}
+
+scoring_variable_name_columns <- c(
+  "name",
+  "Name",
+  "outputName",
+  "OutputName",
+  "scoreName",
+  "ScoreName",
+  "fieldName",
+  "FieldName",
+  "ID",
+  "id"
+)
+
+scoring_variable_response_column_id_columns <- c(
+  "response_column_id",
+  "responseColumnId",
+  "responseColumnID",
+  "columnName",
+  "ColumnName",
+  "exportTag",
+  "ExportTag",
+  "importId",
+  "ImportId",
+  "ID",
+  "id"
+)
+
+scoring_variable_definition_columns <- c(
+  "ScoringCategories",
+  "scoringCategories",
+  "scoring_categories",
+  "categories",
+  "Categories"
+)
+
+scoring_variable_definitions <- function(scoring) {
+  if (is.null(scoring) || !is.list(scoring)) {
+    return(scoring)
+  }
+
+  definition_columns <- intersect(
+    scoring_variable_definition_columns,
+    names(scoring)
+  )
+  if (length(definition_columns) == 0) {
+    return(scoring)
+  }
+
+  scoring[[definition_columns[[1]]]]
+}
+
+valid_scoring_variable_names <- function(output_names) {
+  output_names[!is.na(output_names) & nzchar(output_names)]
+}
+
+scoring_variable_names <- function(scoring) {
+  if (is.null(scoring) || length(scoring) == 0) {
+    return(character())
+  }
+
+  if (is.data.frame(scoring)) {
+    return(scoring_variable_names_from_data_frame(scoring))
+  }
+
+  if (is.atomic(scoring)) {
+    return(scoring_variable_names_from_atomic(scoring))
+  }
+
+  output_names <- map2_chr(
+    scoring,
+    names(scoring) %||% rep(NA_character_, length(scoring)),
+    scoring_variable_name
+  )
+  unname(valid_scoring_variable_names(output_names))
+}
+
+scoring_variable_names_from_data_frame <- function(scoring) {
+  output_columns <- intersect(scoring_variable_name_columns, names(scoring))
+  if (length(output_columns) == 0) {
+    return(character())
+  }
+
+  output_names <- as.character(scoring[[output_columns[[1]]]])
+  valid_scoring_variable_names(output_names)
+}
+
+scoring_variable_names_from_atomic <- function(scoring) {
+  output_names <- as.character(scoring)
+  if (is.null(names(scoring))) {
+    return(valid_scoring_variable_names(output_names))
+  }
+
+  named_outputs <- names(scoring)
+  use_names <- !is.na(named_outputs) & nzchar(named_outputs)
+  output_names[use_names] <- named_outputs[use_names]
+  valid_scoring_variable_names(output_names)
+}
+
+scoring_variable_record <- function(scoring, output_name) {
+  if (is.null(scoring) || is.atomic(scoring) || is.data.frame(scoring)) {
+    return(list())
+  }
+
+  named_index <- match(output_name, names(scoring))
+  if (!is.na(named_index)) {
+    return(scoring[[named_index]])
+  }
+
+  matches <- map_lgl(scoring, function(output) {
+    identical(scoring_variable_name(output), output_name)
+  })
+  if (any(matches)) {
+    return(scoring[[which(matches)[[1]]]])
+  }
+
+  list()
+}
+
+scoring_variable_name <- function(output, fallback_name = NA_character_) {
+  if (is.atomic(output) && length(output) == 1) {
+    return(scalar_character(output))
+  }
+
+  candidates <- map_chr(
+    scoring_variable_name_columns,
+    function(candidate_name) {
+      if (!candidate_name %in% names(output)) {
+        return(NA_character_)
+      }
+
+      scalar_character(output[[candidate_name]])
+    }
+  )
+  candidates <- valid_scoring_variable_names(candidates)
+  if (length(candidates) > 0) {
+    return(candidates[[1]])
+  }
+
+  scalar_character(fallback_name)
+}
+
+scoring_variable_response_column_id <- function(output, output_name) {
+  if (!is.list(output)) {
+    return(output_name)
+  }
+
+  candidates <- map_chr(
+    scoring_variable_response_column_id_columns,
+    function(candidate_name) {
+      if (!candidate_name %in% names(output)) {
+        return(NA_character_)
+      }
+
+      scalar_character(output[[candidate_name]])
+    }
+  )
+  candidates <- valid_scoring_variable_names(candidates)
+  if (length(candidates) > 0) {
+    return(candidates[[1]])
+  }
+
+  output_name
 }
 
 normalise_embedded_data_fields <- function(mt, mt_d) {

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -36,28 +36,44 @@ normalise_scoring_variables <- function(mt_d) {
     mt_d$ScoringData
   scoring <- scoring_variable_definitions(scoring)
   output_names <- scoring_variable_names(scoring)
+  if (length(output_names) == 0) {
+    return(empty_normalised_scoring_variables())
+  }
 
-  variables <- map(output_names, function(output_name) {
-    output <- scoring_variable_record(scoring, output_name)
-    response_column_id <- scoring_variable_response_column_id(
-      output,
-      output_name
-    )
-
-    structure(
-      list(
-        output_name = output_name,
-        response_column_id = response_column_id,
-        question_text = paste("Scoring Variable:", output_name)
-      ),
-      class = c("qualtdict_normalised_scoring_variable", "list")
-    )
-  })
+  variables <- map(
+    output_names,
+    normalise_scoring_variable,
+    scoring = scoring
+  )
   names(variables) <- output_names
 
   structure(
     variables,
     class = c("qualtdict_normalised_scoring_variables", "list")
+  )
+}
+
+empty_normalised_scoring_variables <- function() {
+  structure(
+    list(),
+    class = c("qualtdict_normalised_scoring_variables", "list")
+  )
+}
+
+normalise_scoring_variable <- function(output_name, scoring) {
+  output <- scoring_variable_record(scoring, output_name)
+  response_column_id <- scoring_variable_response_column_id(
+    output,
+    output_name
+  )
+
+  structure(
+    list(
+      output_name = output_name,
+      response_column_id = response_column_id,
+      question_text = paste("Scoring Variable:", output_name)
+    ),
+    class = c("qualtdict_normalised_scoring_variable", "list")
   )
 }
 
@@ -142,8 +158,9 @@ scoring_variable_names_from_data_frame <- function(scoring) {
   if (length(output_columns) == 0) {
     return(character())
   }
+  output_column <- output_columns[[1]]
 
-  output_names <- as.character(scoring[[output_columns[[1]]]])
+  output_names <- as.character(scoring[[output_column]])
   valid_scoring_variable_names(output_names)
 }
 
@@ -160,11 +177,20 @@ scoring_variable_names_from_atomic <- function(scoring) {
 }
 
 scoring_variable_record <- function(scoring, output_name) {
-  if (is.null(scoring) || is.atomic(scoring) || is.data.frame(scoring)) {
+  if (is.null(scoring) || is.atomic(scoring)) {
     return(list())
   }
 
-  named_index <- match(output_name, names(scoring))
+  if (is.data.frame(scoring)) {
+    return(scoring_variable_record_from_data_frame(scoring, output_name))
+  }
+
+  if (length(scoring) == 0) {
+    return(list())
+  }
+
+  scoring_names <- names(scoring) %||% rep(NA_character_, length(scoring))
+  named_index <- match(output_name, scoring_names)
   if (!is.na(named_index)) {
     return(scoring[[named_index]])
   }
@@ -172,11 +198,28 @@ scoring_variable_record <- function(scoring, output_name) {
   matches <- map_lgl(scoring, function(output) {
     identical(scoring_variable_name(output), output_name)
   })
-  if (any(matches)) {
-    return(scoring[[which(matches)[[1]]]])
+  matched_index <- match(TRUE, matches)
+  if (!is.na(matched_index)) {
+    return(scoring[[matched_index]])
   }
 
   list()
+}
+
+scoring_variable_record_from_data_frame <- function(scoring, output_name) {
+  output_columns <- intersect(scoring_variable_name_columns, names(scoring))
+  if (length(output_columns) == 0) {
+    return(list())
+  }
+  output_column <- output_columns[[1]]
+
+  output_names <- as.character(scoring[[output_column]])
+  matched_index <- match(output_name, output_names)
+  if (is.na(matched_index)) {
+    return(list())
+  }
+
+  as.list(scoring[matched_index, , drop = FALSE])
 }
 
 scoring_variable_name <- function(output, fallback_name = NA_character_) {
@@ -184,19 +227,12 @@ scoring_variable_name <- function(output, fallback_name = NA_character_) {
     return(scalar_character(output))
   }
 
-  candidates <- map_chr(
-    scoring_variable_name_columns,
-    function(candidate_name) {
-      if (!candidate_name %in% names(output)) {
-        return(NA_character_)
-      }
-
-      scalar_character(output[[candidate_name]])
-    }
+  candidate <- scoring_variable_metadata_value(
+    output,
+    scoring_variable_name_columns
   )
-  candidates <- valid_scoring_variable_names(candidates)
-  if (length(candidates) > 0) {
-    return(candidates[[1]])
+  if (!is.na(candidate)) {
+    return(candidate)
   }
 
   scalar_character(fallback_name)
@@ -207,22 +243,31 @@ scoring_variable_response_column_id <- function(output, output_name) {
     return(output_name)
   }
 
-  candidates <- map_chr(
-    scoring_variable_response_column_id_columns,
-    function(candidate_name) {
-      if (!candidate_name %in% names(output)) {
-        return(NA_character_)
-      }
-
-      scalar_character(output[[candidate_name]])
-    }
+  candidate <- scoring_variable_metadata_value(
+    output,
+    scoring_variable_response_column_id_columns
   )
+  if (!is.na(candidate)) {
+    return(candidate)
+  }
+
+  output_name
+}
+
+scoring_variable_metadata_value <- function(output, candidate_names) {
+  candidates <- map_chr(candidate_names, function(candidate_name) {
+    if (!candidate_name %in% names(output)) {
+      return(NA_character_)
+    }
+
+    scalar_character(output[[candidate_name]])
+  })
   candidates <- valid_scoring_variable_names(candidates)
   if (length(candidates) > 0) {
     return(candidates[[1]])
   }
 
-  output_name
+  NA_character_
 }
 
 normalise_embedded_data_fields <- function(mt, mt_d) {

--- a/R/variable_dictionary.R
+++ b/R/variable_dictionary.R
@@ -57,7 +57,8 @@ variable_dictionary_from_normalised_metadata <- function(
       normalised_metadata$embedded_data,
       embedded_data_block_assignment = embedded_data_block_assignment,
       quiet = quiet
-    )
+    ),
+    variable_dictionary_scoring_rows(normalised_metadata$scoring)
   )
   if (length(json) == 0) {
     return(empty_variable_dictionary_from_normalised_metadata(
@@ -205,6 +206,38 @@ warn_unassigned_embedded_data_rows <- function(
   }
 
   invisible()
+}
+
+variable_dictionary_scoring_rows <- function(scoring) {
+  imap(
+    scoring %||% list(),
+    variable_dictionary_scoring_row
+  )
+}
+
+variable_dictionary_scoring_row <- function(variable, output_name) {
+  output_name <- variable$output_name %||% output_name
+
+  list(
+    qid = NA_character_,
+    response_column_id = variable$response_column_id %||% output_name,
+    row_source = "scoring",
+    question_name = NA_character_,
+    variable_name = output_name,
+    block = NA_character_,
+    question = variable$question_text %||%
+      paste("Scoring Variable:", output_name),
+    looping_question = NA_character_,
+    item = NA_character_,
+    level = NA_character_,
+    label = NA_character_,
+    type = NA_character_,
+    selector = NA_character_,
+    content_type = NA_character_,
+    sub_selector = NA_character_,
+    looping_option = NA_character_,
+    looping = FALSE
+  )
 }
 
 prepare_variable_dictionary_rows <- function(json) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -110,7 +110,9 @@ the Dictionary Row Source, `qid` as the bare Qualtrics question identifier,
 `question_name` as the raw Qualtrics naming reference, and `variable_name` as
 the final export-safe Dictionary Variable Name. Question-backed rows use
 `row_source = "question"`, and flat Embedded Data Fields defined by Qualtrics
-metadata use `row_source = "embedded_data"`.
+metadata use `row_source = "embedded_data"`. Scoring Variables defined by
+survey description metadata use `row_source = "scoring"` and remain
+unassigned by Survey Block.
 
 ```{r, eval=FALSE}
 survey_id <- "SV_XXXXXXXXXXXXXXXX"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ identifier, `question_name` as the raw Qualtrics naming reference, and
 `variable_name` as the final export-safe Dictionary Variable Name.
 Question-backed rows use `row_source = "question"`, and flat Embedded
 Data Fields defined by Qualtrics metadata use
-`row_source = "embedded_data"`.
+`row_source = "embedded_data"`. Scoring Variables defined by survey
+description metadata use `row_source = "scoring"` and remain unassigned
+by Survey Block.
 
 ``` r
 survey_id <- "SV_XXXXXXXXXXXXXXXX"

--- a/man/dict_generate.Rd
+++ b/man/dict_generate.Rd
@@ -69,10 +69,12 @@ identifier, \code{row_source} as the Dictionary Row Source,
 \code{variable_name} as the final export-safe Dictionary Variable Name used
 by Labelled Survey Data. Question-backed rows use
 \code{row_source = "question"}. Flat Embedded Data Fields defined by
-Qualtrics metadata use \code{row_source = "embedded_data"}. Embedded Data
-Fields remain unassigned by Survey Block unless
+Qualtrics metadata use \code{row_source = "embedded_data"}. Scoring
+Variables defined by survey description metadata use
+\code{row_source = "scoring"}. Embedded Data Fields remain unassigned by
+Survey Block unless
 \code{embedded_data_block_assignment} explicitly requests Survey Flow
-adjacency assignment.
+adjacency assignment. Scoring Variables remain unassigned by Survey Block.
 
 When \code{variable_name = "semantic_name"}, the Variable Dictionary also
 includes \code{semantic_name}. Semantic Names are readable best-effort

--- a/tests/testthat/helper-normalised-metadata.R
+++ b/tests/testthat/helper-normalised-metadata.R
@@ -62,6 +62,26 @@ synthetic_flat_embedded_data_raw_metadata <- function() {
   raw_metadata
 }
 
+synthetic_scoring_raw_metadata <- function() {
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$description$scoring <- list(
+    list(name = "Total Score"),
+    list(name = "Q1")
+  )
+  raw_metadata
+}
+
+synthetic_nested_scoring_raw_metadata <- function() {
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$description$scoring <- list(
+    ScoringCategories = list(
+      list(ID = "SC_TOTAL", Name = "Total Score"),
+      list(ID = "SC_SCREEN")
+    )
+  )
+  raw_metadata
+}
+
 synthetic_survey_flow_embedded_data_raw_metadata <- function() {
   raw_metadata <- synthetic_mc_text_raw_metadata()
   raw_metadata$metadata$questions$QID2 <- raw_metadata$metadata$questions$QID1

--- a/tests/testthat/test-coverage-branches.R
+++ b/tests/testthat/test-coverage-branches.R
@@ -103,6 +103,7 @@ test_that("metadata fetching combines Qualtrics metadata endpoints", {
     fetch_description2 = function(surveyID, elements) {
       expect_identical(surveyID, "SV_FETCH")
       expect_false("responsecounts" %in% elements)
+      expect_true("scoring" %in% elements)
       description
     }
   )

--- a/tests/testthat/test-dict_generate.R
+++ b/tests/testthat/test-dict_generate.R
@@ -107,6 +107,71 @@ test_that("dict_generate represents flat Embedded Data Fields", {
   )
 })
 
+test_that("dict_generate represents Scoring Variables", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_scoring_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate("SV_SYNTHETIC", variable_name = "question_name")
+  scoring_rows <- dict[dict$row_source == "scoring", ]
+
+  expect_identical(
+    scoring_rows$response_column_id,
+    c("Total Score", "Q1")
+  )
+  expect_identical(scoring_rows$row_source, rep("scoring", 2))
+  expect_true(all(is.na(scoring_rows$qid)))
+  expect_true(all(is.na(scoring_rows$question_name)))
+  expect_true(all(is.na(scoring_rows$block)))
+  expect_identical(
+    scoring_rows$variable_name,
+    c("Total_Score", "Q1.2")
+  )
+  expect_identical(
+    scoring_rows$question,
+    c("Scoring Variable: Total Score", "Scoring Variable: Q1")
+  )
+  expect_true(all(is.na(scoring_rows$level)))
+  expect_true(all(is.na(scoring_rows$label)))
+
+  findings <- dict_validate(dict)$validation_findings
+  scoring_findings <- findings[
+    findings$response_column_id %in% scoring_rows$response_column_id,
+  ]
+  expect_identical(
+    scoring_findings$finding,
+    c("repaired_variable_name", "repaired_variable_name")
+  )
+  expect_identical(
+    scoring_findings$reason,
+    c("unsafe", "duplicate")
+  )
+})
+
+test_that("dict_generate represents nested Scoring Categories", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_nested_scoring_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate("SV_SYNTHETIC", variable_name = "question_name")
+  scoring_rows <- dict[dict$row_source == "scoring", ]
+
+  expect_identical(
+    scoring_rows$response_column_id,
+    c("SC_TOTAL", "SC_SCREEN")
+  )
+  expect_identical(
+    scoring_rows$variable_name,
+    c("Total_Score", "SC_SCREEN")
+  )
+  expect_true(all(is.na(scoring_rows$qid)))
+  expect_true(all(is.na(scoring_rows$block)))
+})
+
 test_that("dict_generate assigns Embedded Data Fields to previous blocks", {
   local_mocked_bindings(
     fetch_dictionary_metadata = function(surveyID) {

--- a/tests/testthat/test-fetch_labelled_survey_data.R
+++ b/tests/testthat/test-fetch_labelled_survey_data.R
@@ -125,6 +125,52 @@ test_that(
   }
 )
 
+test_that(
+  paste(
+    "fetch_labelled_survey_data includes",
+    "Scoring Variables by default"
+  ),
+  {
+    dict <- minimal_export_dict(
+      response_column_id = c("QID1", "Total Score"),
+      row_source = c("question", "scoring"),
+      variable_name = c("q1", "Total_Score"),
+      qid = c("QID1", NA_character_),
+      question_name = c("q1", NA_character_),
+      block = c("Block A", NA_character_),
+      question = c("Question q1", "Scoring Variable: Total Score"),
+      label = c("Yes", NA_character_),
+      level = c("1", NA_character_),
+      type = c("MC", NA_character_),
+      selector = c("SAVR", NA_character_),
+      sub_selector = c("TX", NA_character_)
+    )
+    local_mocked_bindings(
+      fetch_survey2 = function(...) {
+        tibble::tibble(
+          QID1 = "1",
+          `Total Score` = "7"
+        )
+      }
+    )
+
+    dat <- fetch_labelled_survey_data(
+      dict,
+      extra_columns = NULL,
+      unanswer_recode_multi = 0
+    )
+
+    expect_named(dat, c("q1", "Total_Score"))
+    expect_identical(as.character(dat$Total_Score), "7")
+    expect_identical(
+      sjlabelled::get_label(dat$Total_Score),
+      "Scoring Variable: Total Score"
+    )
+    expect_null(attr(dat$Total_Score, "labels", exact = TRUE))
+    expect_identical(nrow(labelled_export_findings(dat)), 0L)
+  }
+)
+
 test_that("fetch_labelled_survey_data reports missing Response Column IDs", {
   local_mocked_bindings(
     fetch_survey2 = function(...) {
@@ -196,6 +242,38 @@ test_that("fetch_labelled_survey_data reports missing Embedded Data Fields", {
   expect_identical(findings$response_column_id, "Source Channel")
   expect_true(is.na(findings$qid))
   expect_identical(findings$variable_name, "Source_Channel")
+  expect_identical(findings$reason, "not_found_in_downloaded_survey_data")
+})
+
+test_that("fetch_labelled_survey_data reports missing Scoring Variables", {
+  dict <- minimal_export_dict(
+    response_column_id = c("QID1", "Total Score"),
+    row_source = c("question", "scoring"),
+    variable_name = c("q1", "Total_Score"),
+    qid = c("QID1", NA_character_),
+    question_name = c("q1", NA_character_),
+    block = c("Block A", NA_character_),
+    question = c("Question q1", "Scoring Variable: Total Score"),
+    label = c("Yes", NA_character_),
+    level = c("1", NA_character_),
+    type = c("MC", NA_character_),
+    selector = c("SAVR", NA_character_),
+    sub_selector = c("TX", NA_character_)
+  )
+  local_mocked_bindings(
+    fetch_survey2 = function(...) {
+      tibble::tibble(QID1 = "1")
+    }
+  )
+
+  dat <- fetch_labelled_survey_data(dict, extra_columns = NULL)
+  findings <- labelled_export_findings(dat)
+
+  expect_named(dat, "q1")
+  expect_identical(findings$finding, "missing_response_column_id")
+  expect_identical(findings$response_column_id, "Total Score")
+  expect_true(is.na(findings$qid))
+  expect_identical(findings$variable_name, "Total_Score")
   expect_identical(findings$reason, "not_found_in_downloaded_survey_data")
 })
 

--- a/tests/testthat/test-normalise_metadata.R
+++ b/tests/testthat/test-normalise_metadata.R
@@ -272,6 +272,17 @@ test_that("Scoring Variable names normalise from supported shapes", {
     "Total"
   )
   expect_identical(
+    normalise_scoring_variables(
+      list(
+        scoring = tibble::tibble(
+          Name = "Total",
+          responseColumnId = "SC_TOTAL"
+        )
+      )
+    )[["Total"]]$response_column_id,
+    "SC_TOTAL"
+  )
+  expect_identical(
     scoring_variable_names(tibble::tibble(other = "Total")),
     character()
   )
@@ -316,11 +327,23 @@ test_that("Scoring Variable names normalise from supported shapes", {
     list()
   )
   expect_identical(
-    scoring_variable_record(c("Total"), "Total"),
+    scoring_variable_record("Total", "Total"),
+    list()
+  )
+  expect_identical(
+    scoring_variable_record(list(), "Missing"),
+    list()
+  )
+  expect_identical(
+    scoring_variable_record(tibble::tibble(other = "Total"), "Total"),
     list()
   )
   expect_identical(
     scoring_variable_record(tibble::tibble(name = "Total"), "Total"),
+    list(name = "Total")
+  )
+  expect_identical(
+    scoring_variable_record(tibble::tibble(name = "Total"), "Missing"),
     list()
   )
   expect_identical(

--- a/tests/testthat/test-normalise_metadata.R
+++ b/tests/testthat/test-normalise_metadata.R
@@ -11,7 +11,8 @@ test_that("raw Qualtrics metadata normalises into package-owned metadata", {
       "surveyID",
       "survey_name",
       "questions",
-      "embedded_data"
+      "embedded_data",
+      "scoring"
     )
   )
   expect_identical(normalised_metadata$surveyID, "SV_SYNTHETIC")
@@ -26,6 +27,11 @@ test_that("raw Qualtrics metadata normalises into package-owned metadata", {
     "qualtdict_normalised_embedded_data_fields"
   )
   expect_length(normalised_metadata$embedded_data, 0)
+  expect_s3_class(
+    normalised_metadata$scoring,
+    "qualtdict_normalised_scoring_variables"
+  )
+  expect_length(normalised_metadata$scoring, 0)
 
   question <- normalised_metadata$questions$QID1
   expect_s3_class(question, "qualtdict_normalised_question")
@@ -225,6 +231,108 @@ test_that("Embedded Data Field names normalise from supported flat shapes", {
       list(DataField = "Panel")
     )),
     c("Standalone", "Campaign", "Panel")
+  )
+})
+
+test_that("Scoring Variables normalise from survey description metadata", {
+  scoring <- normalise_qualtrics_metadata(
+    synthetic_scoring_raw_metadata()
+  )$scoring
+
+  expect_named(scoring, c("Total Score", "Q1"))
+  expect_identical(
+    scoring[["Total Score"]]$response_column_id,
+    "Total Score"
+  )
+  expect_identical(
+    scoring[["Total Score"]]$question_text,
+    "Scoring Variable: Total Score"
+  )
+})
+
+test_that("Scoring Variables normalise from nested scoring categories", {
+  scoring <- normalise_qualtrics_metadata(
+    synthetic_nested_scoring_raw_metadata()
+  )$scoring
+
+  expect_named(scoring, c("Total Score", "SC_SCREEN"))
+  expect_identical(
+    scoring[["Total Score"]]$response_column_id,
+    "SC_TOTAL"
+  )
+  expect_identical(
+    scoring[["SC_SCREEN"]]$response_column_id,
+    "SC_SCREEN"
+  )
+})
+
+test_that("Scoring Variable names normalise from supported shapes", {
+  expect_identical(
+    scoring_variable_names(tibble::tibble(name = c("Total", "", NA))),
+    "Total"
+  )
+  expect_identical(
+    scoring_variable_names(tibble::tibble(other = "Total")),
+    character()
+  )
+  expect_identical(
+    scoring_variable_names(c("Total", "", NA)),
+    "Total"
+  )
+  expect_identical(
+    scoring_variable_names(c(Total = "ignored", "")),
+    "Total"
+  )
+  expect_identical(
+    scoring_variable_names(list(
+      "Standalone",
+      Weighted = list(responseColumnId = "SC_1"),
+      list(outputName = "Percent"),
+      list(ID = "SC_2")
+    )),
+    c("Standalone", "Weighted", "Percent", "SC_2")
+  )
+  expect_identical(
+    scoring_variable_names(
+      scoring_variable_definitions(
+        list(ScoringCategories = list(list(ID = "SC_3", Name = "Nested")))
+      )
+    ),
+    "Nested"
+  )
+  expect_identical(
+    scoring_variable_response_column_id(
+      list(name = "Weighted", responseColumnId = "SC_1"),
+      "Weighted"
+    ),
+    "SC_1"
+  )
+  expect_identical(
+    scoring_variable_response_column_id("SC_4", "SC_4"),
+    "SC_4"
+  )
+  expect_identical(
+    scoring_variable_record(NULL, "Missing"),
+    list()
+  )
+  expect_identical(
+    scoring_variable_record(c("Total"), "Total"),
+    list()
+  )
+  expect_identical(
+    scoring_variable_record(tibble::tibble(name = "Total"), "Total"),
+    list()
+  )
+  expect_identical(
+    scoring_variable_record(
+      list(Total = list(responseColumnId = "SC_5")),
+      "Total"
+    ),
+    list(responseColumnId = "SC_5")
+  )
+  expect_identical(
+    scoring_variable_record(list(list(name = "Other")), "Missing"),
+    list()
   )
 })
 


### PR DESCRIPTION
## Summary

Represent Qualtrics scoring variables as metadata-defined export variables in generated dictionaries and labelled exports.

Fixes #16

## Verification

- Rscript -e 'devtools::test()'\n- Rscript tools/local-finalize-smoke.R check --functions dict_generate,fetch_labelled_survey_data --variable-name question_name\n- git push -u origin sandcastle/issue-16 ran pre-push hooks; R CMD check passed, but local pkgcheck failed to detect GitHub CI despite successful Actions runs existing on main.