### PR TITLE
Represent text-analysis sidecars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
   description metadata as Metadata-defined Export Variable rows with
   `row_source = "scoring"`.
 
+- `dict_generate()` now represents Text-analysis Sidecars from Qualtrics
+  metadata as Metadata-defined Export Variable rows with
+  `row_source = "text_analysis"` and parent question context when a clear
+  parent QID is available.
+
 - `dict_generate()` now accepts `embedded_data_block_assignment` to optionally
   assign Survey Flow Embedded Data Fields to the nearest previous or next
   Survey Block while leaving them unassigned by default.

--- a/R/dict_generate.R
+++ b/R/dict_generate.R
@@ -45,6 +45,10 @@
 #' Survey Block unless
 #' \code{embedded_data_block_assignment} explicitly requests Survey Flow
 #' adjacency assignment. Scoring Variables remain unassigned by Survey Block.
+#' Text-analysis Sidecars defined by Qualtrics metadata
+#' use \code{row_source = "text_analysis"} and inherit parent \code{qid},
+#' \code{question_name}, and \code{block} when a clear parent QID can be
+#' determined.
 #'
 #' When \code{variable_name = "semantic_name"}, the Variable Dictionary also
 #' includes \code{semantic_name}. Semantic Names are readable best-effort

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -16,6 +16,11 @@ normalise_qualtrics_metadata <- function(raw_metadata) {
     raw_metadata$description
   )
   scoring <- normalise_scoring_variables(raw_metadata$description)
+  text_analysis <- normalise_text_analysis_sidecars(
+    raw_metadata$metadata,
+    raw_metadata$description,
+    questions
+  )
 
   structure(
     list(
@@ -23,7 +28,8 @@ normalise_qualtrics_metadata <- function(raw_metadata) {
       survey_name = raw_metadata$survey_name,
       questions = questions,
       embedded_data = embedded_data,
-      scoring = scoring
+      scoring = scoring,
+      text_analysis = text_analysis
     ),
     class = c("qualtdict_normalised_metadata", "list")
   )
@@ -609,6 +615,211 @@ embedded_data_field_name <- function(field, fallback_name = NA_character_) {
   }
 
   scalar_character(fallback_name)
+}
+
+normalise_text_analysis_sidecars <- function(mt, mt_d, questions) {
+  sidecar_records <- text_analysis_sidecar_records(mt, mt_d)
+  if (length(sidecar_records) == 0) {
+    return(empty_normalised_text_analysis_sidecars())
+  }
+
+  sidecars <- imap(sidecar_records, function(sidecar, fallback_name) {
+    normalise_text_analysis_sidecar(sidecar, fallback_name, questions)
+  }) |>
+    discard(is.null)
+
+  names(sidecars) <- map_chr(sidecars, "sidecar_name")
+
+  structure(
+    sidecars,
+    class = c("qualtdict_normalised_text_analysis_sidecars", "list")
+  )
+}
+
+text_analysis_sidecar_records <- function(mt, mt_d) {
+  sources <- list(
+    mt$text_analysis,
+    mt$textAnalysis,
+    mt$textAnalysisSidecars,
+    mt$comments,
+    mt_d$text_analysis,
+    mt_d$textAnalysis,
+    mt_d$textAnalysisSidecars,
+    mt_d$comments
+  )
+  sources <- discard(sources, is.null)
+  if (length(sources) == 0) {
+    return(list())
+  }
+
+  do.call(c, args = map(sources, text_analysis_sidecar_record_list))
+}
+
+text_analysis_sidecar_record_list <- function(sidecars) {
+  if (is.null(sidecars) || length(sidecars) == 0) {
+    return(list())
+  }
+
+  if (is.data.frame(sidecars)) {
+    return(map(seq_len(nrow(sidecars)), function(row) {
+      as.list(sidecars[row, , drop = FALSE])
+    }))
+  }
+
+  if (is_text_analysis_sidecar_record(sidecars)) {
+    return(list(sidecars))
+  }
+
+  if (is.atomic(sidecars)) {
+    return(as.list(sidecars))
+  }
+
+  sidecars
+}
+
+is_text_analysis_sidecar_record <- function(sidecar) {
+  is.list(sidecar) &&
+    any(
+      c(
+        text_analysis_sidecar_name_columns,
+        text_analysis_sidecar_response_column_id_columns,
+        text_analysis_sidecar_parent_qid_columns
+      ) %in%
+        names(sidecar)
+    )
+}
+
+normalise_text_analysis_sidecar <- function(
+  sidecar,
+  fallback_name,
+  questions
+) {
+  sidecar_name <- text_analysis_sidecar_name(sidecar, fallback_name)
+  if (is.na(sidecar_name) || !nzchar(sidecar_name)) {
+    return(NULL)
+  }
+
+  parent_qid <- text_analysis_sidecar_parent_qid(sidecar)
+  parent_question <- NULL
+  if (!is.na(parent_qid)) {
+    parent_question <- questions[[parent_qid]]
+  }
+  if (is.na(parent_qid) || is.null(parent_question)) {
+    parent_qid <- NA_character_
+  }
+
+  structure(
+    list(
+      sidecar_name = sidecar_name,
+      response_column_id = text_analysis_sidecar_response_column_id(
+        sidecar,
+        sidecar_name
+      ),
+      question_text = paste("Text Analysis:", sidecar_name),
+      parent_qid = parent_qid,
+      parent_question_name = if (!is.na(parent_qid)) {
+        parent_question$question_name
+      } else {
+        NA_character_
+      },
+      parent_block = if (!is.na(parent_qid)) {
+        parent_question$survey_block
+      } else {
+        NA_character_
+      }
+    ),
+    class = c("qualtdict_normalised_text_analysis_sidecar", "list")
+  )
+}
+
+text_analysis_sidecar_name_columns <- c(
+  "outputName",
+  "output_name",
+  "name",
+  "fieldName",
+  "field_name",
+  "variableName",
+  "variable_name",
+  "DataField",
+  "id",
+  "ID"
+)
+
+text_analysis_sidecar_response_column_id_columns <- c(
+  "responseColumnId",
+  "responseColumnID",
+  "response_column_id",
+  "columnName",
+  "column_name",
+  "importId",
+  "import_id"
+)
+
+text_analysis_sidecar_parent_qid_columns <- c(
+  "questionId",
+  "questionID",
+  "question_id",
+  "parentQid",
+  "parent_qid",
+  "qid",
+  "QID"
+)
+
+text_analysis_sidecar_name <- function(
+  sidecar,
+  fallback_name = NA_character_
+) {
+  text_analysis_sidecar_scalar(
+    sidecar,
+    text_analysis_sidecar_name_columns,
+    fallback_name = fallback_name
+  )
+}
+
+text_analysis_sidecar_response_column_id <- function(sidecar, sidecar_name) {
+  text_analysis_sidecar_scalar(
+    sidecar,
+    text_analysis_sidecar_response_column_id_columns,
+    fallback_name = sidecar_name
+  )
+}
+
+text_analysis_sidecar_parent_qid <- function(sidecar) {
+  text_analysis_sidecar_scalar(
+    sidecar,
+    text_analysis_sidecar_parent_qid_columns
+  )
+}
+
+text_analysis_sidecar_scalar <- function(
+  sidecar,
+  columns,
+  fallback_name = NA_character_
+) {
+  if (is.atomic(sidecar) && length(sidecar) == 1) {
+    return(scalar_character(sidecar))
+  }
+
+  candidates <- map_chr(columns, function(candidate_name) {
+    if (!candidate_name %in% names(sidecar)) {
+      return(NA_character_)
+    }
+
+    scalar_character(sidecar[[candidate_name]])
+  })
+  candidates <- candidates[!is.na(candidates) & nzchar(candidates)]
+  if (length(candidates) > 0) {
+    return(candidates[[1]])
+  }
+
+  scalar_character(fallback_name)
+}
+
+empty_normalised_text_analysis_sidecars <- function() {
+  structure(
+    list(),
+    class = c("qualtdict_normalised_text_analysis_sidecars", "list")
+  )
 }
 
 #' Merge raw question, block, and content-type metadata

--- a/R/metadata_normalise.R
+++ b/R/metadata_normalise.R
@@ -699,14 +699,7 @@ normalise_text_analysis_sidecar <- function(
     return(NULL)
   }
 
-  parent_qid <- text_analysis_sidecar_parent_qid(sidecar)
-  parent_question <- NULL
-  if (!is.na(parent_qid)) {
-    parent_question <- questions[[parent_qid]]
-  }
-  if (is.na(parent_qid) || is.null(parent_question)) {
-    parent_qid <- NA_character_
-  }
+  parent_context <- text_analysis_sidecar_parent_context(sidecar, questions)
 
   structure(
     list(
@@ -716,19 +709,37 @@ normalise_text_analysis_sidecar <- function(
         sidecar_name
       ),
       question_text = paste("Text Analysis:", sidecar_name),
-      parent_qid = parent_qid,
-      parent_question_name = if (!is.na(parent_qid)) {
-        parent_question$question_name
-      } else {
-        NA_character_
-      },
-      parent_block = if (!is.na(parent_qid)) {
-        parent_question$survey_block
-      } else {
-        NA_character_
-      }
+      parent_qid = parent_context$parent_qid,
+      parent_question_name = parent_context$parent_question_name,
+      parent_block = parent_context$parent_block
     ),
     class = c("qualtdict_normalised_text_analysis_sidecar", "list")
+  )
+}
+
+text_analysis_sidecar_parent_context <- function(sidecar, questions) {
+  parent_qid <- text_analysis_sidecar_parent_qid(sidecar)
+  if (is.na(parent_qid)) {
+    return(empty_text_analysis_sidecar_parent_context())
+  }
+
+  parent_question <- questions[[parent_qid]]
+  if (is.null(parent_question)) {
+    return(empty_text_analysis_sidecar_parent_context())
+  }
+
+  list(
+    parent_qid = parent_qid,
+    parent_question_name = parent_question$question_name,
+    parent_block = parent_question$survey_block
+  )
+}
+
+empty_text_analysis_sidecar_parent_context <- function() {
+  list(
+    parent_qid = NA_character_,
+    parent_question_name = NA_character_,
+    parent_block = NA_character_
   )
 }
 

--- a/R/variable_dictionary.R
+++ b/R/variable_dictionary.R
@@ -250,6 +250,8 @@ variable_dictionary_text_analysis_rows <- function(text_analysis) {
 
 variable_dictionary_text_analysis_row <- function(sidecar, sidecar_name) {
   sidecar_name <- sidecar$sidecar_name %||% sidecar_name
+  question_text <- sidecar$question_text %||%
+    paste("Text Analysis:", sidecar_name)
 
   list(
     qid = sidecar$parent_qid %||% NA_character_,
@@ -258,7 +260,7 @@ variable_dictionary_text_analysis_row <- function(sidecar, sidecar_name) {
     question_name = sidecar$parent_question_name %||% NA_character_,
     variable_name = sidecar_name,
     block = sidecar$parent_block %||% NA_character_,
-    question = sidecar$question_text %||% paste("Text Analysis:", sidecar_name),
+    question = question_text,
     looping_question = NA_character_,
     item = NA_character_,
     level = NA_character_,

--- a/R/variable_dictionary.R
+++ b/R/variable_dictionary.R
@@ -58,7 +58,8 @@ variable_dictionary_from_normalised_metadata <- function(
       embedded_data_block_assignment = embedded_data_block_assignment,
       quiet = quiet
     ),
-    variable_dictionary_scoring_rows(normalised_metadata$scoring)
+    variable_dictionary_scoring_rows(normalised_metadata$scoring),
+    variable_dictionary_text_analysis_rows(normalised_metadata$text_analysis)
   )
   if (length(json) == 0) {
     return(empty_variable_dictionary_from_normalised_metadata(
@@ -227,6 +228,37 @@ variable_dictionary_scoring_row <- function(variable, output_name) {
     block = NA_character_,
     question = variable$question_text %||%
       paste("Scoring Variable:", output_name),
+    looping_question = NA_character_,
+    item = NA_character_,
+    level = NA_character_,
+    label = NA_character_,
+    type = NA_character_,
+    selector = NA_character_,
+    content_type = NA_character_,
+    sub_selector = NA_character_,
+    looping_option = NA_character_,
+    looping = FALSE
+  )
+}
+
+variable_dictionary_text_analysis_rows <- function(text_analysis) {
+  imap(
+    text_analysis %||% list(),
+    variable_dictionary_text_analysis_row
+  )
+}
+
+variable_dictionary_text_analysis_row <- function(sidecar, sidecar_name) {
+  sidecar_name <- sidecar$sidecar_name %||% sidecar_name
+
+  list(
+    qid = sidecar$parent_qid %||% NA_character_,
+    response_column_id = sidecar$response_column_id %||% sidecar_name,
+    row_source = "text_analysis",
+    question_name = sidecar$parent_question_name %||% NA_character_,
+    variable_name = sidecar_name,
+    block = sidecar$parent_block %||% NA_character_,
+    question = sidecar$question_text %||% paste("Text Analysis:", sidecar_name),
     looping_question = NA_character_,
     item = NA_character_,
     level = NA_character_,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -48,6 +48,7 @@ preprocess
 programmingLanguage
 propsed
 purrr
+QID
 qids
 qualtdict
 qualtRics

--- a/man/dict_generate.Rd
+++ b/man/dict_generate.Rd
@@ -75,6 +75,10 @@ Variables defined by survey description metadata use
 Survey Block unless
 \code{embedded_data_block_assignment} explicitly requests Survey Flow
 adjacency assignment. Scoring Variables remain unassigned by Survey Block.
+Text-analysis Sidecars defined by Qualtrics metadata
+use \code{row_source = "text_analysis"} and inherit parent \code{qid},
+\code{question_name}, and \code{block} when a clear parent QID can be
+determined.
 
 When \code{variable_name = "semantic_name"}, the Variable Dictionary also
 includes \code{semantic_name}. Semantic Names are readable best-effort

--- a/tests/testthat/helper-normalised-metadata.R
+++ b/tests/testthat/helper-normalised-metadata.R
@@ -82,6 +82,27 @@ synthetic_nested_scoring_raw_metadata <- function() {
   raw_metadata
 }
 
+synthetic_text_analysis_raw_metadata <- function() {
+  raw_metadata <- synthetic_mc_text_raw_metadata()
+  raw_metadata$metadata$comments <- list(
+    list(
+      outputName = "Q1 Sentiment",
+      responseColumnId = "QID1_TEXT_SENTIMENT",
+      questionId = "QID1"
+    ),
+    `Q1 Topic` = list(
+      responseColumnId = "QID1_TEXT_TOPIC",
+      questionId = "QID1"
+    ),
+    list(
+      outputName = "Q1",
+      responseColumnId = "Unmatched Topic",
+      questionId = "QID99"
+    )
+  )
+  raw_metadata
+}
+
 synthetic_survey_flow_embedded_data_raw_metadata <- function() {
   raw_metadata <- synthetic_mc_text_raw_metadata()
   raw_metadata$metadata$questions$QID2 <- raw_metadata$metadata$questions$QID1

--- a/tests/testthat/test-dict_generate.R
+++ b/tests/testthat/test-dict_generate.R
@@ -172,6 +172,67 @@ test_that("dict_generate represents nested Scoring Categories", {
   expect_true(all(is.na(scoring_rows$block)))
 })
 
+test_that("dict_generate represents Text-analysis Sidecars", {
+  local_mocked_bindings(
+    fetch_dictionary_metadata = function(surveyID) {
+      synthetic_text_analysis_raw_metadata()
+    }
+  )
+
+  dict <- dict_generate("SV_SYNTHETIC", variable_name = "question_name")
+  sidecar_rows <- dict[dict$row_source == "text_analysis", ]
+
+  expect_identical(
+    sidecar_rows$response_column_id,
+    c("QID1_TEXT_SENTIMENT", "QID1_TEXT_TOPIC", "Unmatched Topic")
+  )
+  expect_identical(sidecar_rows$row_source, rep("text_analysis", 3))
+  expect_identical(sidecar_rows$qid, c("QID1", "QID1", NA_character_))
+  expect_identical(sidecar_rows$question_name, c("Q1", "Q1", NA_character_))
+  expect_identical(
+    sidecar_rows$block,
+    c("Main Block", "Main Block", NA_character_)
+  )
+  expect_identical(
+    sidecar_rows$variable_name,
+    c("Q1_Sentiment", "Q1_Topic", "Q1.2")
+  )
+  expect_identical(
+    sidecar_rows$question,
+    c(
+      "Text Analysis: Q1 Sentiment",
+      "Text Analysis: Q1 Topic",
+      "Text Analysis: Q1"
+    )
+  )
+  expect_true(all(is.na(sidecar_rows$level)))
+  expect_true(all(is.na(sidecar_rows$label)))
+
+  findings <- attr(dict, "variable_name_findings", exact = TRUE)
+  sidecar_findings <- findings[
+    findings$response_column_id %in% sidecar_rows$response_column_id,
+  ]
+  expect_identical(
+    sidecar_findings$response_column_id,
+    c("QID1_TEXT_SENTIMENT", "QID1_TEXT_TOPIC", "Unmatched Topic")
+  )
+  expect_identical(
+    unname(sidecar_findings$reason),
+    c("unsafe", "unsafe", "duplicate")
+  )
+
+  validation_findings <- dict_validate(dict)$validation_findings
+  repaired_findings <- validation_findings[
+    validation_findings$finding == "repaired_variable_name" &
+      validation_findings$response_column_id %in%
+        sidecar_rows$response_column_id,
+  ]
+  expect_identical(
+    repaired_findings$response_column_id,
+    c("QID1_TEXT_SENTIMENT", "QID1_TEXT_TOPIC", "Unmatched Topic")
+  )
+})
+
 test_that("dict_generate assigns Embedded Data Fields to previous blocks", {
   local_mocked_bindings(
     fetch_dictionary_metadata = function(surveyID) {

--- a/tests/testthat/test-dict_validate.R
+++ b/tests/testthat/test-dict_validate.R
@@ -184,3 +184,21 @@ test_that("dict_validate skips level-label checks for Embedded Data Fields", {
   expect_false(any(findings$finding == "level_label_mistake"))
   expect_true(any(findings$finding == "unsafe_variable_name"))
 })
+
+test_that("dict_validate skips level-label checks for Text-analysis Sidecars", {
+  dict <- minimal_validation_dict(
+    response_column_id = c("TA1", "TA1", "TA1", "TA2"),
+    row_source = "text_analysis",
+    qid = c("QID1", "QID1", "QID1", NA_character_),
+    question_name = c("Q1", "Q1", "Q1", NA_character_),
+    variable_name = c("bad name", "bad name", "bad name", "bad name"),
+    block = c("Main Block", "Main Block", "Main Block", NA_character_),
+    label = c("A", "A", "B", "C"),
+    level = c("1", "1", "3", "1")
+  )
+
+  findings <- dict_validate(dict)$validation_findings
+
+  expect_false(any(findings$finding == "level_label_mistake"))
+  expect_true(any(findings$finding == "unsafe_variable_name"))
+})

--- a/tests/testthat/test-fetch_labelled_survey_data.R
+++ b/tests/testthat/test-fetch_labelled_survey_data.R
@@ -171,6 +171,52 @@ test_that(
   }
 )
 
+test_that(
+  paste(
+    "fetch_labelled_survey_data includes",
+    "Text-analysis Sidecars by default"
+  ),
+  {
+    dict <- minimal_export_dict(
+      response_column_id = c("QID1", "QID1_TEXT_SENTIMENT"),
+      row_source = c("question", "text_analysis"),
+      variable_name = c("q1", "Q1_Text_Sentiment"),
+      qid = c("QID1", "QID1"),
+      question_name = c("q1", "q1"),
+      block = c("Block A", "Block A"),
+      question = c("Question q1", "Text Analysis: Q1 Text Sentiment"),
+      label = c("Yes", NA_character_),
+      level = c("1", NA_character_),
+      type = c("MC", NA_character_),
+      selector = c("SAVR", NA_character_),
+      sub_selector = c("TX", NA_character_)
+    )
+    local_mocked_bindings(
+      fetch_survey2 = function(...) {
+        tibble::tibble(
+          QID1 = "1",
+          QID1_TEXT_SENTIMENT = "positive"
+        )
+      }
+    )
+
+    dat <- fetch_labelled_survey_data(
+      dict,
+      extra_columns = NULL,
+      unanswer_recode_multi = 0
+    )
+
+    expect_named(dat, c("q1", "Q1_Text_Sentiment"))
+    expect_identical(as.character(dat$Q1_Text_Sentiment), "positive")
+    expect_identical(
+      sjlabelled::get_label(dat$Q1_Text_Sentiment),
+      "Text Analysis: Q1 Text Sentiment"
+    )
+    expect_null(attr(dat$Q1_Text_Sentiment, "labels", exact = TRUE))
+    expect_identical(nrow(labelled_export_findings(dat)), 0L)
+  }
+)
+
 test_that("fetch_labelled_survey_data reports missing Response Column IDs", {
   local_mocked_bindings(
     fetch_survey2 = function(...) {
@@ -274,6 +320,38 @@ test_that("fetch_labelled_survey_data reports missing Scoring Variables", {
   expect_identical(findings$response_column_id, "Total Score")
   expect_true(is.na(findings$qid))
   expect_identical(findings$variable_name, "Total_Score")
+  expect_identical(findings$reason, "not_found_in_downloaded_survey_data")
+})
+
+test_that("fetch_labelled_survey_data reports missing Text-analysis Sidecars", {
+  dict <- minimal_export_dict(
+    response_column_id = c("QID1", "QID1_TEXT_SENTIMENT"),
+    row_source = c("question", "text_analysis"),
+    variable_name = c("q1", "Q1_Text_Sentiment"),
+    qid = c("QID1", "QID1"),
+    question_name = c("q1", "q1"),
+    block = c("Block A", "Block A"),
+    question = c("Question q1", "Text Analysis: Q1 Text Sentiment"),
+    label = c("Yes", NA_character_),
+    level = c("1", NA_character_),
+    type = c("MC", NA_character_),
+    selector = c("SAVR", NA_character_),
+    sub_selector = c("TX", NA_character_)
+  )
+  local_mocked_bindings(
+    fetch_survey2 = function(...) {
+      tibble::tibble(QID1 = "1")
+    }
+  )
+
+  dat <- fetch_labelled_survey_data(dict, extra_columns = NULL)
+  findings <- labelled_export_findings(dat)
+
+  expect_named(dat, "q1")
+  expect_identical(findings$finding, "missing_response_column_id")
+  expect_identical(findings$response_column_id, "QID1_TEXT_SENTIMENT")
+  expect_identical(findings$qid, "QID1")
+  expect_identical(findings$variable_name, "Q1_Text_Sentiment")
   expect_identical(findings$reason, "not_found_in_downloaded_survey_data")
 })
 

--- a/tests/testthat/test-normalise_metadata.R
+++ b/tests/testthat/test-normalise_metadata.R
@@ -113,6 +113,28 @@ test_that("Text-analysis Sidecars normalise with parent question context", {
   expect_true(is.na(text_analysis[["Q1"]]$parent_block))
 })
 
+test_that("Text-analysis Sidecar fallback paths normalise", {
+  expect_null(
+    normalise_text_analysis_sidecar(
+      list(outputName = ""),
+      fallback_name = NA_character_,
+      questions = list()
+    )
+  )
+  expect_identical(
+    text_analysis_sidecar_parent_context(list(), list()),
+    list(
+      parent_qid = NA_character_,
+      parent_question_name = NA_character_,
+      parent_block = NA_character_
+    )
+  )
+  expect_identical(
+    text_analysis_sidecar_name("Q1 Sentiment"),
+    "Q1 Sentiment"
+  )
+})
+
 test_that("Text-analysis Sidecar record shapes normalise", {
   expect_identical(text_analysis_sidecar_record_list(NULL), list())
   expect_identical(text_analysis_sidecar_record_list(list()), list())

--- a/tests/testthat/test-normalise_metadata.R
+++ b/tests/testthat/test-normalise_metadata.R
@@ -12,7 +12,8 @@ test_that("raw Qualtrics metadata normalises into package-owned metadata", {
       "survey_name",
       "questions",
       "embedded_data",
-      "scoring"
+      "scoring",
+      "text_analysis"
     )
   )
   expect_identical(normalised_metadata$surveyID, "SV_SYNTHETIC")
@@ -32,6 +33,11 @@ test_that("raw Qualtrics metadata normalises into package-owned metadata", {
     "qualtdict_normalised_scoring_variables"
   )
   expect_length(normalised_metadata$scoring, 0)
+  expect_s3_class(
+    normalised_metadata$text_analysis,
+    "qualtdict_normalised_text_analysis_sidecars"
+  )
+  expect_length(normalised_metadata$text_analysis, 0)
 
   question <- normalised_metadata$questions$QID1
   expect_s3_class(question, "qualtdict_normalised_question")
@@ -70,6 +76,67 @@ test_that("flat Embedded Data Fields normalise into package-owned metadata", {
   expect_identical(
     embedded_data[["Source Channel"]]$question_text,
     "Embedded Data: Source Channel"
+  )
+})
+
+test_that("Text-analysis Sidecars normalise with parent question context", {
+  raw_metadata <- synthetic_text_analysis_raw_metadata()
+
+  text_analysis <- normalise_qualtrics_metadata(raw_metadata)$text_analysis
+
+  expect_s3_class(
+    text_analysis,
+    "qualtdict_normalised_text_analysis_sidecars"
+  )
+  expect_named(text_analysis, c("Q1 Sentiment", "Q1 Topic", "Q1"))
+  expect_s3_class(
+    text_analysis[["Q1 Sentiment"]],
+    "qualtdict_normalised_text_analysis_sidecar"
+  )
+  expect_identical(
+    text_analysis[["Q1 Sentiment"]]$response_column_id,
+    "QID1_TEXT_SENTIMENT"
+  )
+  expect_identical(text_analysis[["Q1 Sentiment"]]$parent_qid, "QID1")
+  expect_identical(
+    text_analysis[["Q1 Sentiment"]]$parent_question_name,
+    "Q1"
+  )
+  expect_identical(text_analysis[["Q1 Sentiment"]]$parent_block, "Main Block")
+  expect_identical(
+    text_analysis[["Q1 Topic"]]$response_column_id,
+    "QID1_TEXT_TOPIC"
+  )
+  expect_identical(text_analysis[["Q1 Topic"]]$sidecar_name, "Q1 Topic")
+  expect_true(is.na(text_analysis[["Q1"]]$parent_qid))
+  expect_true(is.na(text_analysis[["Q1"]]$parent_question_name))
+  expect_true(is.na(text_analysis[["Q1"]]$parent_block))
+})
+
+test_that("Text-analysis Sidecar record shapes normalise", {
+  expect_identical(text_analysis_sidecar_record_list(NULL), list())
+  expect_identical(text_analysis_sidecar_record_list(list()), list())
+
+  data_frame_records <- text_analysis_sidecar_record_list(
+    tibble::tibble(
+      outputName = c("Sentiment", "Topic"),
+      responseColumnId = c("QID1_TEXT_SENTIMENT", "QID1_TEXT_TOPIC")
+    )
+  )
+  expect_length(data_frame_records, 2)
+  expect_identical(data_frame_records[[1]]$outputName, "Sentiment")
+
+  direct_record <- list(
+    outputName = "Emotion",
+    responseColumnId = "QID1_TEXT_EMOTION"
+  )
+  expect_identical(
+    text_analysis_sidecar_record_list(direct_record),
+    list(direct_record)
+  )
+  expect_identical(
+    text_analysis_sidecar_record_list(c(Sentiment = "QID1_TEXT_SENTIMENT")),
+    list(Sentiment = "QID1_TEXT_SENTIMENT")
   )
 })
 


### PR DESCRIPTION
## Summary

Represent Qualtrics text-analysis sidecars as metadata-defined export variables with parent question context when a clear parent QID is available.

Fixes #17

## Verification

- Rscript -e 'devtools::test()'\n- Rscript tools/local-finalize-smoke.R check --functions dict_generate,fetch_labelled_survey_data --variable-name question_name\n- git push -u origin sandcastle/issue-17