### PR TITLE
Fix response-column-id parity: embedded, Captcha, TE/FORM, carry-forward MC

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 ^.*\.Rds$
+^.*\.Rproj$
 ^AGENTS\.md$
 ^CONTEXT\.md$
 ^LICENSE\.md$
@@ -9,8 +10,9 @@
 ^\.Renviron$
 ^\.Rhistory$
 ^\.Rproj\.user$
-^.*\.Rproj$
 ^\.agents$
+^\.codegraph$
+^\.codegraph/
 ^\.codex$
 ^\.direnv$
 ^\.direnv/
@@ -31,6 +33,8 @@
 ^\.sandcastle/
 ^\.superpowers$
 ^\.superpowers/
+^\.understand-anything$
+^\.understand-anything/
 ^\.workflow$
 ^\.workflow/
 ^\.worktrees$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # qualtdict 0.0.0.9000
 
+- `dict_generate()` now resolves response-column-id parity with Qualtrics
+  exports for embedded, Captcha, Text-entry/FORM, and carry-forward
+  multiple-choice questions: colliding embedded fields honour the Qualtrics
+  QSED export-rename, Captcha and `analyze == FALSE` text-entry fields are
+  suppressed (no export column), and carry-forward multiple-choice export
+  choiceIds are derived from survey-definition `RecodeValues`/`DynamicChoices`
+  rather than sequential `/surveys` recodes.
+
 - `dict_generate()` now preserves question context while representing
   Embedded Data Fields when Qualtrics description metadata uses the
   `blocks`/`questions` structure returned by `qualtRics::fetch_description()`.

--- a/R/embedded_data_normalise.R
+++ b/R/embedded_data_normalise.R
@@ -133,12 +133,40 @@ filter_exported_embedded_data_fields <- function(
     return(fields)
   }
 
+  fields <- map(fields, function(field) {
+    field$response_column_id <- resolve_exported_response_column_id(
+      field$response_column_id,
+      response_column_ids
+    )
+    field
+  })
   keep <- map_lgl(fields, function(field) {
     field$response_column_id %in% response_column_ids
   })
   fields <- fields[keep]
 
   new_normalised_embedded_data_fields(fields)
+}
+
+#' Resolve an Embedded Data field's exported Response Column ID
+#'
+#' Qualtrics renames Embedded Data fields whose name collides with a
+#' reserved export column (e.g. `ResponseID`) by prepending a `QSED`
+#' prefix on export. Prefer the declared name; otherwise fall back to
+#' the `QSED`-prefixed exported column when that is what was exported.
+#' @noRd
+resolve_exported_response_column_id <- function(
+  response_column_id,
+  response_column_ids
+) {
+  if (response_column_id %in% response_column_ids) {
+    return(response_column_id)
+  }
+  prefixed <- paste0("QSED", response_column_id)
+  if (prefixed %in% response_column_ids) {
+    return(prefixed)
+  }
+  response_column_id
 }
 
 #' Flatten Survey Flow items relevant to metadata normalisation

--- a/R/question_facts.R
+++ b/R/question_facts.R
@@ -11,12 +11,25 @@ scalar_character <- function(x) {
 #' Build one package-owned Normalised Question Fact
 #' @importFrom rlang %||%
 #' @noRd
-normalise_question_fact <- function(qid, question, block, content_type) {
+normalise_question_fact <- function(
+  qid,
+  question,
+  block,
+  content_type,
+  description = NULL
+) {
   question_name <- scalar_character(question$questionName)
   question_text <- scalar_character(question$questionText)
   question_type <- question_fact_question_type(question)
   survey_block <- scalar_character(block$description)
-  response_choices <- normalise_response_choices(question$choices)
+  recode_override <- resolve_dynamic_choice_recode_override(
+    question,
+    description
+  )
+  response_choices <- normalise_response_choices(
+    question$choices,
+    recode_override
+  )
   response_items <- normalise_response_items(question$subQuestions)
   column_facts <- normalise_column_facts(question$columns)
   choice_order <- as.character(question$choiceOrder %||% character())
@@ -50,9 +63,60 @@ normalise_question_fact <- function(qid, question, block, content_type) {
   )
 }
 
+#' Resolve export choice IDs for dynamic / carry-forward multiple choice
+#'
+#' Qualtrics renumbers the choices of carry-forward (dynamic-choice) questions
+#' sequentially in the question metadata (`mt`), but the real export column
+#' suffixes are the original Qualtrics choice IDs. These true IDs are only
+#' recoverable from the survey *description* metadata (`mt_d`): either verbatim
+#' from `RecodeValues`, or, when that is absent, by offsetting each
+#' carried-forward choice's source ID (`x<N>` key) by the maximum of the
+#' question's own static choice IDs. Non-dynamic questions are left untouched.
+#' @noRd
+resolve_dynamic_choice_recode_override <- function(question, description) {
+  if (is.null(description)) {
+    return(NULL)
+  }
+  dynamic <- description$DynamicChoices
+  if (is.null(dynamic) || is.null(dynamic$Locator)) {
+    return(NULL)
+  }
+
+  choice_ids <- names(question$choices)
+  if (is.null(choice_ids) || length(choice_ids) == 0) {
+    return(NULL)
+  }
+
+  # Tier 1: RecodeValues carries the export choice IDs verbatim.
+  recode_values <- description$RecodeValues
+  if (!is.null(recode_values) && length(recode_values) > 0) {
+    return(vapply(recode_values, scalar_character, character(1)))
+  }
+
+  # Tier 2: derive the export choice ID for each carried-forward choice.
+  own_keys <- suppressWarnings(as.integer(names(description$Choices)))
+  own_keys <- own_keys[!is.na(own_keys)]
+  offset <- if (length(own_keys) > 0) max(own_keys) else 0L
+
+  carried <- regmatches(choice_ids, regexec("^x([0-9]+)$", choice_ids))
+  override <- vapply(
+    seq_along(choice_ids),
+    function(i) {
+      match <- carried[[i]]
+      if (length(match) == 2L) {
+        as.character(offset + as.integer(match[[2]]))
+      } else {
+        choice_ids[[i]]
+      }
+    },
+    character(1)
+  )
+  setNames(override, choice_ids)
+}
+
 #' Build package-owned response choice facts
 #' @noRd
-normalise_response_choices <- function(choices) {
+normalise_response_choices <- function(choices, recode_override = NULL) {
   imap(choices, function(choice, choice_id) {
     label <- scalar_character(choice$label %||% choice$description)
     text_entry <- "text_entry" %in%
@@ -63,12 +127,21 @@ normalise_response_choices <- function(choices) {
       analyze <- TRUE
     }
 
+    recode <- choice$level %||% choice$recode
+    if (
+      !is.null(recode_override) &&
+        choice_id %in% names(recode_override) &&
+        !is.na(recode_override[[choice_id]])
+    ) {
+      recode <- recode_override[[choice_id]]
+    }
+
     list(
       choice_id = choice_id,
-      level = scalar_character(choice$level %||% choice$recode),
+      level = scalar_character(recode),
       label = label,
       text_entry = text_entry,
-      recode = scalar_character(choice$level %||% choice$recode),
+      recode = scalar_character(recode),
       description = label,
       analyze = isTRUE(analyze),
       textEntry = if (text_entry) TRUE else NULL

--- a/R/question_facts.R
+++ b/R/question_facts.R
@@ -94,7 +94,16 @@ resolve_dynamic_choice_recode_override <- function(question, description) {
   }
 
   # Tier 2: derive the export choice ID for each carried-forward choice.
-  own_keys <- suppressWarnings(as.integer(names(description$Choices)))
+  derive_carryforward_choice_ids(choice_ids, description$Choices)
+}
+
+#' Derive export choice IDs for carried-forward choices
+#'
+#' Offsets each carried-forward choice's source ID (`x<N>` key) by the maximum
+#' of the question's own static choice IDs; own static choices keep their key.
+#' @noRd
+derive_carryforward_choice_ids <- function(choice_ids, own_choices) {
+  own_keys <- suppressWarnings(as.integer(names(own_choices)))
   own_keys <- own_keys[!is.na(own_keys)]
   offset <- if (length(own_keys) > 0) max(own_keys) else 0L
 

--- a/R/question_metadata_normalise.R
+++ b/R/question_metadata_normalise.R
@@ -15,7 +15,8 @@ normalise_qualtrics_questions <- function(mt, mt_d) {
       qid = qid,
       question = question,
       block = block_meta[[qid]] %||% default_question_block_metadata(),
-      content_type = content_type_meta[[qid]]
+      content_type = content_type_meta[[qid]],
+      description = mt_d[["questions"]][[qid]]
     )
   })
 

--- a/R/response_column_render.R
+++ b/R/response_column_render.R
@@ -467,6 +467,11 @@ question_choices_render_independent_columns <- function(question) {
   if (identical(type, "Matrix")) {
     return(identical(sub_selector, "MultipleAnswer"))
   }
+  if (identical(type, "TE")) {
+    # Text-entry FORM questions emit one export column per choice, and
+    # Qualtrics omits the column for any choice whose `analyze` flag is FALSE.
+    return(identical(selector, "FORM"))
+  }
 
   FALSE
 }
@@ -581,6 +586,7 @@ response_column_renderer_table <- function() {
     Draw = list(Signature = render_file_upload_response_column_ids),
     HL = list(Text = render_response_column_id_with_level_and_item_suffixes),
     Meta = list(Browser = render_unsupported_response_column_ids),
+    Captcha = list(V2 = render_no_response_column_ids),
     DB = response_column_display_renderer_table()
   )
 }
@@ -624,9 +630,15 @@ render_response_column_id_with_level_suffix <- function(context) {
 #' @noRd
 render_response_column_id_with_named_label_suffix <- function(context) {
   # Add recode values to the end of the Base Response Column ID.
+  choice_ids <- names(context$render_facts$level)
+  if (length(choice_ids) == 0) {
+    # Every choice was suppressed (e.g. all `analyze == FALSE`), so the
+    # question exports no columns.
+    return(character(0))
+  }
   paste(
     context$base_response_column_id,
-    names(context$render_facts$level),
+    choice_ids,
     sep = "_"
   )
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,9 +2,11 @@ al
 api
 aut
 BugReports
+Captcha
 CMD
 Codecov
 codecov
+choiceIds
 codemeta
 codeRepository
 ComputerLanguage
@@ -25,6 +27,7 @@ fileSize
 gh
 github
 givenName
+honour
 https
 io
 issueTracker
@@ -49,6 +52,7 @@ programmingLanguage
 propsed
 purrr
 QID
+QSED
 qids
 qualtdict
 qualtRics

--- a/tests/testthat/test-local_finalize_smoke.R
+++ b/tests/testthat/test-local_finalize_smoke.R
@@ -759,7 +759,7 @@ test_that("local finalize smoke rejects legacy survey selection flags", {
   )
 })
 
-test_that("local finalize smoke config keeps the seven-survey surface", {
+test_that("local finalize smoke config keeps the thirteen-survey surface", {
   config_path <- testthat::test_path(
     "..",
     "..",
@@ -778,7 +778,7 @@ test_that("local finalize smoke config keeps the seven-survey surface", {
     grep('"alias":', config_lines, value = TRUE, fixed = TRUE)
   )
 
-  expect_length(aliases, 7L)
+  expect_length(aliases, 13L)
   expect_identical(
     aliases,
     c(
@@ -788,7 +788,13 @@ test_that("local finalize smoke config keeps the seven-survey surface", {
       "edgi_optional_all",
       "glad_sa6_signup",
       "edgi_medications",
-      "glad_medications"
+      "glad_medications",
+      "ramp",
+      "coping_glad",
+      "coping_edgi",
+      "coping_nbr",
+      "coping_fupb_ongoing",
+      "ramp_fupb"
     )
   )
 })

--- a/tests/testthat/test-parity-fixes.R
+++ b/tests/testthat/test-parity-fixes.R
@@ -1,0 +1,143 @@
+test_that("resolve_exported_response_column_id prefers the declared name", {
+  expect_identical(
+    resolve_exported_response_column_id(
+      "ResponseId",
+      c("ResponseId", "Q1")
+    ),
+    "ResponseId"
+  )
+})
+
+test_that("resolve_exported_response_column_id falls back to the QSED prefix", {
+  expect_identical(
+    resolve_exported_response_column_id(
+      "ResponseId",
+      c("QSEDResponseId", "Q1")
+    ),
+    "QSEDResponseId"
+  )
+})
+
+test_that("resolve_exported_response_column_id returns the input unchanged", {
+  expect_identical(
+    resolve_exported_response_column_id("ResponseId", "Q1"),
+    "ResponseId"
+  )
+})
+
+test_that("dynamic choice recode override uses RecodeValues verbatim", {
+  question <- list(choices = list(x1 = list(), x2 = list()))
+  description <- list(
+    DynamicChoices = list(Locator = "q://QID1/ChoiceGroup/SelectedChoices"),
+    RecodeValues = list(`1` = "10", `2` = "20")
+  )
+
+  expect_identical(
+    resolve_dynamic_choice_recode_override(question, description),
+    stats::setNames(c("10", "20"), c("1", "2"))
+  )
+})
+
+test_that("dynamic choice recode override derives IDs by static-key offset", {
+  question <- list(
+    choices = list(x1 = list(), x2 = list(), x2_TEXT = list())
+  )
+  description <- list(
+    DynamicChoices = list(Locator = "q://QID1/ChoiceGroup/SelectedChoices"),
+    Choices = list(`1` = list(), `2` = list())
+  )
+
+  # own static keys max to 2, so carried x1/x2 export as 3/4 and the
+  # text-entry choice ID is left untouched.
+  expect_identical(
+    resolve_dynamic_choice_recode_override(question, description),
+    stats::setNames(c("3", "4", "x2_TEXT"), c("x1", "x2", "x2_TEXT"))
+  )
+})
+
+test_that("dynamic choice recode override offsets from zero without own keys", {
+  question <- list(
+    choices = list(x1 = list(), x2 = list(), x2_TEXT = list())
+  )
+  description <- list(
+    DynamicChoices = list(Locator = "q://QID1/ChoiceGroup/SelectedChoices")
+  )
+
+  expect_identical(
+    resolve_dynamic_choice_recode_override(question, description),
+    stats::setNames(c("1", "2", "x2_TEXT"), c("x1", "x2", "x2_TEXT"))
+  )
+})
+
+test_that("dynamic choice recode override is a no-op without carried choices", {
+  question <- list(choices = list(x1 = list(), x2 = list()))
+
+  # No description at all, or no DynamicChoices, leaves the question untouched.
+  expect_null(resolve_dynamic_choice_recode_override(question, NULL))
+  expect_null(resolve_dynamic_choice_recode_override(question, list()))
+
+  # DynamicChoices present but the question carries no choices.
+  dynamic <- list(
+    DynamicChoices = list(Locator = "q://QID1/ChoiceGroup/SelectedChoices")
+  )
+  expect_null(
+    resolve_dynamic_choice_recode_override(list(choices = list()), dynamic)
+  )
+})
+
+test_that("normalise_response_choices applies a recode override", {
+  choices <- normalise_response_choices(
+    list(x1 = list(description = "A"), x2 = list(description = "B")),
+    stats::setNames(c("3", "4"), c("x1", "x2"))
+  )
+
+  expect_identical(choices$x1$recode, "3")
+  expect_identical(choices$x1$level, "3")
+  expect_identical(choices$x2$recode, "4")
+})
+
+test_that("FORM questions with all choices suppressed export no columns", {
+  question <- normalise_question_fact(
+    qid = "QID1",
+    question = list(
+      questionName = "form_q",
+      questionType = list(type = "TE", selector = "FORM", subSelector = NULL),
+      questionText = "Form",
+      choices = list(
+        `1` = list(description = "A", analyze = FALSE),
+        `2` = list(description = "B", analyze = FALSE)
+      ),
+      subQuestions = list(),
+      columns = list()
+    ),
+    block = list(description = "Main Block"),
+    content_type = NULL
+  )
+
+  rendered <- render_response_columns(question, "QID1")
+
+  expect_identical(nrow(rendered), 0L)
+})
+
+test_that("FORM questions still export analysed choice columns", {
+  question <- normalise_question_fact(
+    qid = "QID1",
+    question = list(
+      questionName = "form_q",
+      questionType = list(type = "TE", selector = "FORM", subSelector = NULL),
+      questionText = "Form",
+      choices = list(
+        `1` = list(description = "A", analyze = FALSE),
+        `2` = list(description = "B", analyze = TRUE)
+      ),
+      subQuestions = list(),
+      columns = list()
+    ),
+    block = list(description = "Main Block"),
+    content_type = NULL
+  )
+
+  rendered <- render_response_columns(question, "QID1")
+
+  expect_identical(rendered$response_column_id, "QID1_2")
+})

--- a/tools/local-finalize-smoke-surveys.json
+++ b/tools/local-finalize-smoke-surveys.json
@@ -31,6 +31,26 @@
     {
       "alias": "ramp",
       "survey_id": "SV_0DrSSOISyMOqN5r"
+    },
+    {
+      "alias": "coping_glad",
+      "survey_id": "SV_2l4GhidotLEBzYp"
+    },
+    {
+      "alias": "coping_edgi",
+      "survey_id": "SV_5gXHZjBhmhorErP"
+    },
+    {
+      "alias": "coping_nbr",
+      "survey_id": "SV_4PyAHbAxpdbyacl"
+    },
+    {
+      "alias": "coping_fupb_ongoing",
+      "survey_id": "SV_0NFXuNfs4US1Iod"
+    },
+    {
+      "alias": "ramp_fupb",
+      "survey_id": "SV_0UFM1iul4AJhVfn"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes response-column-id parity between generated dictionaries and Qualtrics exports for four question shapes that previously drifted. Verified across a 32-survey offline parity sweep (all 32 now pass; 6 were failing before).

All fixes are principled and metadata-only — no hardcoded survey/QID literals; each keys on question type/selector or survey-definition structure.

## Root causes fixed

| Fix | File | Behaviour |
|---|---|---|
| **QSED embedded export-rename** | `R/embedded_data_normalise.R` | Embedded-data fields whose name collides with a reserved export column (e.g. `ResponseID`) are renamed by Qualtrics with a `QSED` prefix on export. `resolve_exported_response_column_id()` now resolves the field to its exported id (falling back to the `QSED`-prefixed name), so it is emitted in the dict. |
| **Captcha skip** | `R/response_column_render.R` | `Captcha`/`V2` questions produce no export column; added to the true-skip renderer (like `DB`), so no phantom `QID` column is emitted. |
| **TE/FORM `analyze == FALSE` suppression** | `R/response_column_render.R` | Text-entry FORM fields flagged `analyze == FALSE` are excluded from the Qualtrics export; the renderer now suppresses them (returns `character(0)` when all are suppressed). |
| **Carry-forward MC choiceIds** | `R/question_facts.R`, `R/question_metadata_normalise.R` | Dynamic/carry-forward multiple-choice questions are renumbered sequentially in `/surveys` metadata, but export suffixes are the original Qualtrics choice IDs. These are now derived from the survey-definition (`RecodeValues` verbatim, else offset carried `x<N>` keys by the max own static key). |

## Tests & tooling

- New `tests/testthat/test-parity-fixes.R` covering all four behaviours (both recode tiers, QSED fallback, empty-guard). Package coverage 100%.
- Expanded `tools/local-finalize-smoke-surveys.json` from 8 → 13 to cover the affected surveys; corrected the surface-count test.
- `.Rbuildignore`: exclude dev-tool dirs `.codegraph`/`.understand-anything` (R CMD check hidden-files NOTE).
- `inst/WORDLIST`: technical-term spelling additions.

## Verification (in-nix)

- `devtools::test()` → **931 pass, 0 fail**
- coverage → **100%**
- 32-survey offline response-column-id parity → **32/32 OK**
- `goodpractice::gp()` → **fully green**
